### PR TITLE
chore: Add installation instructions for Cursor and explain skill auto-discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,25 @@ Install a plugin:
 /plugin install expo-deployment
 ```
 
+## Cursor
+
+**Install from GitHub**
+
+1. Open Cursor Settings (Cmd+Shift+J / Ctrl+Shift+J)
+2. Navigate to `Rules & Command` → `Project Rules` → Add Rule → Remote Rule (GitHub)
+3. Enter: `https://github.com/expo/skills.git`
+
+**How it works:** Skills are automatically discovered and used by the agent based on context. When you ask questions about Expo development, the agent will automatically use the relevant skills (e.g., `building-ui`, `data-fetching`, `deployment`) based on the skill descriptions.
+
+**Note:** Skills won't appear in the `/` slash command menu. The `/` menu in Cursor is for custom commands (stored in `.cursor/commands/`), not for skills. Skills work via auto-discovery - the agent uses them automatically when your questions match their descriptions.
+
+**Verify installation:** After adding the Remote Rule, try asking the agent Expo-related questions like:
+- "How do I build a UI with Expo Router?"
+- "How do I make API calls in my Expo app?"
+- "How do I deploy my Expo app to the App Store?"
+
+If the skills are working, the agent will use the relevant skill content to answer your questions.
+
 ## Any agent
 
 ```


### PR DESCRIPTION
# Add Cursor installation instructions

## Problem

The README was missing installation instructions for Cursor users. Users needed guidance on how to install and use Expo skills in Cursor, and there was confusion about whether skills would appear in the `/` slash command menu.

## Solution

Added a new "Cursor" section to the README with:

1. **Installation steps**: Clear instructions for adding the skills repository as a Remote Rule in Cursor
2. **How skills work**: Explanation that skills use auto-discovery based on context and skill descriptions
3. **Important clarification**: Note that skills won't appear in the `/` menu (which is for custom commands, not skills)
4. **Verification steps**: Example questions users can ask to verify their installation is working correctly

## Changes

- Added new "Cursor" section with installation instructions
- Explained skill auto-discovery behavior in Cursor
- Clarified that skills don't appear in `/` menu (to prevent confusion)
- Added verification section with example questions

## Impact

Cursor users now have clear documentation on:
- How to install Expo skills in Cursor
- How skills are automatically discovered and used
- How to verify their installation is working
- Why skills don't appear in the slash command menu

This makes the skills repository more accessible to Cursor users and prevents confusion about skill discovery.
