### PR TITLE
docs: add AdaL as compatible AI coding agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ Install a plugin:
 
 If the skills are working, the agent will use the relevant skill content to answer your questions.
 
+## AdaL
+
+[AdaL](https://sylph.ai) is a self-evolving AI coding agent that's compatible with Claude Code skills.
+
+```bash
+/plugin marketplace add expo/skills
+/plugin install expo-app-design
+```
+
 ## Any agent
 
 ```


### PR DESCRIPTION
## Summary

Adds [AdaL](https://sylph.ai) to the list of compatible AI coding agents.

## About AdaL

AdaL is a self-evolving AI coding agent that is fully compatible with Claude Code skills and plugins. Users can install Expo skills using the same plugin marketplace commands.

## Changes

- Added AdaL section with installation instructions between Cursor and Any agent sections

---

🌸 Generated with [AdaL](https://github.com/SylphAI-Inc/adal-cli)