### PR TITLE
fix: quote backticks in SKILL.md descriptions to fix YAML parsing

### DIFF
--- a/plugins/expo/skills/expo-ui-jetpack-compose/SKILL.md
+++ b/plugins/expo/skills/expo-ui-jetpack-compose/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Expo UI Jetpack Compose
-description: `@expo/ui/jetpack-compose` package lets you use Jetpack Compose Views and modifiers in your app.
+description: "`@expo/ui/jetpack-compose` package lets you use Jetpack Compose Views and modifiers in your app."
 ---
 
 > The instructions in this skill apply to SDK 55 only. For other SDK versions, refer to the Expo UI Jetpack Compose docs for that version for the most accurate information.

--- a/plugins/expo/skills/expo-ui-swift-ui/SKILL.md
+++ b/plugins/expo/skills/expo-ui-swift-ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Expo UI SwiftUI
-description: `@expo/ui/swift-ui` package lets you use SwiftUI Views and modifiers in your app.
+description: "`@expo/ui/swift-ui` package lets you use SwiftUI Views and modifiers in your app."
 ---
 
 > The instructions in this skill apply to SDK 55 only. For other SDK versions, refer to the Expo UI SwiftUI docs for that version for the most accurate information.


### PR DESCRIPTION
## Summary

- Fixes `expo-ui-swift-ui` and `expo-ui-jetpack-compose` skills being silently skipped during `bunx skills add expo/skills`
- The `description` fields contained unquoted backticks (`` ` ``), which are invalid YAML and cause `gray-matter` to throw a parse error
- Wraps the descriptions in double quotes so YAML parses them correctly

Fixes #34

## Test plan

- [ ] Run `bunx skills add expo/skills --list` and verify all 11 skills appear (including `Expo UI SwiftUI` and `Expo UI Jetpack Compose`)