### PR TITLE
feat: add integration skill for expo/examples

### DIFF
--- a/plugins/expo/README.md
+++ b/plugins/expo/README.md
@@ -65,6 +65,7 @@ Official AI agent skills from the Expo team for building, deploying, upgrading, 
 - **expo-ui-swift-ui** — SwiftUI components for Expo
 - **native-data-fetching** — Network requests, API calls, caching, and offline support
 - **use-dom** — Run web code in a webview on native using DOM components
+- **add-integration** — Add popular integrations (auth, payments, database, styling, animations, etc.) from expo/examples
 
 ### Deployment
 

--- a/plugins/expo/skills/add-integration/SKILL.md
+++ b/plugins/expo/skills/add-integration/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: add-integration
+description: Add a popular integration to an Expo project (auth, payments, database, styling, animations, state management, camera, maps, GraphQL). Use when the user wants to add a new feature, library, or third-party integration to their Expo app.
+version: 1.0.0
+license: MIT
+---
+
+# Add Integration
+
+Fetch and follow the integration guide from [expo/examples](https://github.com/expo/examples):
+
+```
+https://raw.githubusercontent.com/expo/examples/master/SKILL.md
+```


### PR DESCRIPTION
Adds the add-integration skill that guides users through adding popular integrations (auth, payments, database, etc.) from the expo/examples repo.

The expo/examples has a root skill that this skill references.

Examples PR: https://github.com/expo/examples/pull/673