### PR TITLE
Update create-expo-module skill

### DIFF
--- a/plugins/expo/skills/expo-module/SKILL.md
+++ b/plugins/expo/skills/expo-module/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: expo-module
-description: Guide for writing Expo native modules and views using the Expo Modules API (Swift, Kotlin, TypeScript). Covers module definition DSL, native views, shared objects, config plugins, lifecycle hooks, autolinking, and type system. Use when building or modifying native modules for Expo.
+description: Guide for creating and writing Expo native modules and views using the Expo Modules API (Swift, Kotlin, TypeScript). Covers module definition DSL, native views, shared objects, config plugins, lifecycle hooks, autolinking, and type system. Use when building or modifying native modules for Expo.
 version: 1.0.0
 license: MIT
 ---
@@ -15,6 +15,9 @@ Complete reference for building native modules and views using the Expo Modules 
 - Adding native functionality (camera, sensors, system APIs) to an Expo app
 - Wrapping platform SDKs for React Native consumption
 - Building config plugins that modify native project files
+- Adding Android, Apple, or web support to an existing Expo module
+- Editing `expo-module.config.json`, config plugins, or lifecycle hooks
+
 
 ## References
 
@@ -22,91 +25,56 @@ Consult these resources as needed:
 
 ```
 references/
+  create-expo-module.md      Scaffolding and add-platform-support workflow, defaults, and quirks
   native-module.md           Module definition DSL: Name, Function, AsyncFunction, Property, Constant, Events, type system, shared objects
   native-view.md             Native view components: View, Prop, EventDispatcher, view lifecycle, ref-based functions
   lifecycle.md               Lifecycle hooks: module, iOS app/AppDelegate, Android activity/application listeners
   config-plugin.md           Config plugins: modifying Info.plist, AndroidManifest.xml, reading values in native code
-  module-config.md           expo-module.config.json fields and autolinking configuration
+  module-config.md           expo-module.config.json fields, file placement, and autolinking behavior
 ```
 
 ## Quick Start
 
-### Create a Local Module (in existing app)
+Prefer `create-expo-module` over manually creating native module files and directories. In practice, the best path is usually to create the scaffold first and then build on top of it. The scaffold sets up the expected layout, `expo-module.config.json`, podspec or Gradle files, TypeScript bindings, and the standalone example app flow.
 
-**Always scaffold with `create-expo-module` first**, then modify the generated code. This ensures correct podspec, build.gradle, and module config — avoiding common build errors.
+If an existing Expo module only needs another platform, use `create-expo-module add-platform-support` instead of manually copying native directories.
 
-```bash
-CI=1 npx create-expo-module@latest --local \
-  --name MyModule \
-  --description "My Expo module" \
-  --package expo.modules.mymodule
-```
+See [references/create-expo-module.md](references/create-expo-module.md) before scaffolding or extending a module. It covers:
 
-`CI=1` skips interactive prompts and uses the provided flags.
+- local vs standalone modules
+- `--platform`, `--features`, `--barrel`, `--package-manager`, and non-interactive mode
+- `expo.autolinking.nativeModulesDir`
+- `add-platform-support` behavior and quirks
 
-> **Important:** In `CI=1` (non-interactive) mode, the scaffold always creates the directory as `modules/my-module/` because the slug is derived from `customTargetPath` which is `undefined` for `--local` modules — the `--name` flag only sets the native class name, not the directory. After scaffolding, rename it to a kebab-case name matching your module (e.g., `KeyValueStore` → `modules/key-value-store/`), then run `cd ios && pod install` so CocoaPods picks up the correct path. Skipping the rename is fine functionally, but skipping `pod install` after any rename causes iOS build failures ("Build input file cannot be found").
+## Recommended Workflow
 
-Available flags:
+1. Choose the scaffold type first:
+   - **Local module** for one app
+   - **Standalone module** for reuse, monorepos, or publishing
+2. Scaffold deliberately:
+   - pass an explicit slug or path
+   - choose `--platform` intentionally instead of relying on defaults
+   - add only the feature examples you actually want
+3. Replace generated example code with the real implementation.
+4. Remove unused generated files when needed:
+   - remove web bindings if the module is native-only
+   - remove view files if the module does not render UI
+   - remove module function examples if you only need a view
+5. If you add a new platform later, prefer `add-platform-support` over manual file copying.
 
-| Flag | Description | Example |
-|------|-------------|---------|
-| `--name` | Native module name (PascalCase) | `--name KeyValueStore` |
-| `--description` | Module description | `--description "Native key-value storage"` |
-| `--package` | Android package name | `--package expo.modules.keyvaluestore` |
-| `--author-name` | Author name | `--author-name "dev"` |
-| `--author-email` | Author email | `--author-email "dev@example.com"` |
-| `--author-url` | Author profile URL | `--author-url "https://github.com/dev"` |
-| `--repo` | Repository URL | `--repo "https://github.com/dev/repo"` |
+## Practical Scaffolding Rules
 
-The scaffold generates both a **native module** (functions, events, constants) and a **native view component** (WebView example with props and events). After scaffolding:
+- Feature examples are **opt-in**. A newly scaffolded module may be minimal if no features were selected.
+- `ViewEvent` implies `View`.
+- Local modules do **not** generate an `index.ts` barrel by default. Use `--barrel` only if you want one.
+- In non-interactive local scaffolding, pass the positional slug or path explicitly. `--name` changes the native class name, not the folder name.
+- Local modules live in `expo.autolinking.nativeModulesDir` when configured, otherwise in `modules/`.
+- Standalone modules have their own package metadata, scripts, and usually an example app. Local modules use the host app's tooling instead.
 
-1. **Decide what you need**: If you only need a native module (no UI), remove the view files. If you only need a native view, remove the module function boilerplate. If you need both, keep both and replace the implementations.
-2. **Remove unnecessary boilerplate**: The scaffold includes example code (`hello()` function, `PI` constant, `onChange` event, WebView-based view with `url` prop). Strip all of this and replace with your actual implementation.
-3. **Remove web files if not needed**: The scaffold generates `*.web.ts`/`*.web.tsx` files for web platform support. Remove these if the module is native-only. Also remove `"web"` from the `platforms` array in `expo-module.config.json`.
 
-#### What to remove for a module-only (no native view):
+## Core File Shapes
 
-- Delete `ios/MyModuleView.swift`, `android/.../MyModuleView.kt`
-- Delete `src/MyModuleView.tsx`, `src/MyModuleView.web.tsx`
-- Remove the `View(...)` block from the module definition in both Swift and Kotlin
-- Remove view-related types from `MyModule.types.ts` and view export from `index.ts`
-
-#### What to remove for a view-only (no module functions):
-
-- Remove `Function`, `AsyncFunction`, `Constant`, `Events` blocks from the module definition (keep `Name` and `View`)
-- Simplify the TypeScript module file to only export the view
-
-Generated structure (after renaming from `my-module` to your module's kebab-case name):
-
-```
-modules/
-  my-module/                     # Rename to kebab-case, e.g. key-value-store/
-    android/
-      build.gradle
-      src/main/java/expo/modules/mymodule/
-        MyModule.kt              # Module definition (functions, events, view registration)
-        MyModuleView.kt          # Native view (ExpoView subclass)
-    ios/
-      MyModule.podspec
-      MyModule.swift             # Module definition
-      MyModuleView.swift         # Native view (ExpoView subclass)
-    src/
-      MyModule.ts                # Native module binding
-      MyModule.web.ts            # Web implementation
-      MyModule.types.ts          # Shared types
-      MyModuleView.tsx           # Native view component
-      MyModuleView.web.tsx       # Web view component
-    expo-module.config.json
-    index.ts                     # Re-exports module + view
-```
-
-### Create a Standalone Module (for publishing)
-
-```bash
-npx create-expo-module@latest my-module
-```
-
----
+The Swift and Kotlin DSL share the same structure. Swift is usually the clearest primary example; consult the references for feature-specific details.
 
 ## Module Structure Reference
 

--- a/plugins/expo/skills/expo-module/SKILL.md
+++ b/plugins/expo/skills/expo-module/SKILL.md
@@ -18,7 +18,6 @@ Complete reference for building native modules and views using the Expo Modules 
 - Adding Android, Apple, or web support to an existing Expo module
 - Editing `expo-module.config.json`, config plugins, or lifecycle hooks
 
-
 ## References
 
 Consult these resources as needed:
@@ -51,15 +50,14 @@ See [references/create-expo-module.md](references/create-expo-module.md) before 
 1. Choose the scaffold type first:
    - **Local module** for one app
    - **Standalone module** for reuse, monorepos, or publishing
-2. Scaffold deliberately:
+2. Determine native `expo-module` features that you will need.
+   - Based on the user's instructions determine which feature scaffolding will be useful.
+   - Available features: `Constant`, `Function`, `AsyncFunction`, `Event`, `View`,`ViewEvent`, `SharedObject`
+3. Scaffold deliberately:
    - pass an explicit slug or path
    - choose `--platform` intentionally instead of relying on defaults
-   - add only the feature examples you actually want
-3. Replace generated example code with the real implementation.
-4. Remove unused generated files when needed:
-   - remove web bindings if the module is native-only
-   - remove view files if the module does not render UI
-   - remove module function examples if you only need a view
+   - use `--features` to choose code samples which you will modify in the next stepto match the real implementation.
+4. Replace generated example code with the real implementation.
 5. If you add a new platform later, prefer `add-platform-support` over manual file copying.
 
 ## Practical Scaffolding Rules
@@ -70,7 +68,6 @@ See [references/create-expo-module.md](references/create-expo-module.md) before 
 - In non-interactive local scaffolding, pass the positional slug or path explicitly. `--name` changes the native class name, not the folder name.
 - Local modules live in `expo.autolinking.nativeModulesDir` when configured, otherwise in `modules/`.
 - Standalone modules have their own package metadata, scripts, and usually an example app. Local modules use the host app's tooling instead.
-
 
 ## Core File Shapes
 

--- a/plugins/expo/skills/expo-module/references/create-expo-module.md
+++ b/plugins/expo/skills/expo-module/references/create-expo-module.md
@@ -1,0 +1,205 @@
+# create-expo-module
+
+Use `create-expo-module` to scaffold new Expo modules and `create-expo-module add-platform-support` to extend existing Expo modules.
+
+Prefer `create-expo-module` over manually creating module files and directories. In most cases, the right move is to generate the scaffold first and then build on top of it.
+
+## Choose the Module Type First
+
+### Local module
+
+Use a local module when the native code only belongs to one Expo app.
+
+- lives inside the app
+- uses the app's dependencies and tooling
+- does not create an example app
+- respects `package.json:expo.autolinking.nativeModulesDir`, or falls back to `modules/`
+
+### Standalone module
+
+Use a standalone module when the module should be reusable across apps, live in a monorepo package, or be published to npm.
+
+- has its own `package.json`
+- installs its own dependencies
+- builds TypeScript during scaffolding
+- usually creates an `example` app unless `--no-example` is passed
+- may initialize a Git repo if not already inside one
+
+When creating a standalone module, default to keeping the example app. Only skip it when the user explicitly asks for `--no-example` or clearly does not want the example project.
+
+## Recommended Commands
+
+### Local module
+
+Use an explicit slug or path.
+
+```bash
+npx create-expo-module@latest key-value-store --local --platform apple android --features Function AsyncFunction
+```
+
+If you need deterministic non-interactive output, pass the slug or path explicitly and then pass the rest of the options:
+
+```bash
+CI=1 npx create-expo-module@latest key-value-store \
+  --local \
+  --name KeyValueStore \
+  --package expo.modules.keyvaluestore \
+  --platform apple android \
+  --features Function AsyncFunction
+```
+
+Important quirk:
+
+- in non-interactive local scaffolding, omitting the positional slug causes the CLI to fall back to `my-module`
+- `--name` changes the native module class name, not the directory name
+
+### Standalone module
+
+```bash
+npx create-expo-module@latest expo-key-value-store --platform apple android --features Function AsyncFunction
+```
+
+## Creation Options
+
+These are the module creation options exposed by the CLI:
+
+| Option | Applies to | Notes |
+| --- | --- | --- |
+| `[path]` | local, standalone | Positional slug or target path. Use this explicitly for stable local scaffolding in non-interactive mode. |
+| `--local` | local | Create a local module inside the current Expo project. |
+| `--platform <platforms...>` | local, standalone | Valid values: `apple`, `android`, `web`. |
+| `--features <features...>` | local, standalone | Pick generated feature examples. Use `all` to include everything. |
+| `--full-example` | local, standalone | Equivalent to `--features all`. |
+| `--barrel` | local | Generate a local `index.ts` barrel. Ignored for standalone modules. |
+| `--source <source_dir>` | local, standalone | Use a local `expo-module-template` directory instead of downloading from npm. |
+| `--name <name>` | local, standalone | Native module name, for example `KeyValueStore`. |
+| `--description <description>` | standalone | Package description. |
+| `--package <package>` | local, standalone | Android package name, for example `expo.modules.keyvaluestore`. |
+| `--author-name <name>` | standalone | Package author name. |
+| `--author-email <email>` | standalone | Package author email. |
+| `--author-url <url>` | standalone | Package author profile URL. |
+| `--repo <url>` | standalone | Package repository URL. |
+| `--license <license>` | standalone | Package license identifier. |
+| `--module-version <version>` | standalone | Initial package version. |
+| `--package-manager <manager>` | standalone | One of `npm`, `pnpm`, `yarn`, `bun`. |
+| `--with-readme` | standalone | Keep `README.md` in the generated package. |
+| `--with-changelog` | standalone | Keep `CHANGELOG.md` in the generated package. |
+| `--no-example` | standalone | Skip creating the example app. |
+
+Notes:
+
+- `--description`, author flags, `--repo`, `--license`, and `--module-version` only affect standalone modules because local modules do not have a standalone package manifest.
+- `--with-readme`, `--with-changelog`, `--no-example`, and `--package-manager` are standalone-only concerns.
+- `--barrel` only affects local modules.
+- `--name` changes the native module class name. It does not rename the local module directory.
+
+## Platforms
+
+Valid values are:
+
+- `apple`
+- `android`
+- `web`
+
+Behavior to remember:
+
+- standalone modules default to all platforms when `--platform` is omitted in non-interactive mode
+- local modules also default to all platforms in non-interactive mode
+- interactive local scaffolding preselects platforms from `app.json:expo.platforms` when available, mapping `ios` to `apple`
+- invalid platform values are ignored with a warning; if all provided values are invalid, the CLI falls back to all platforms
+
+If you do not want web support, omit `web` during scaffolding instead of removing it later.
+
+## Feature Examples
+
+Feature examples are generated starter snippets, not capability restrictions. They are small working examples of common Expo Modules API patterns.
+
+Available values:
+
+- `Constant`
+- `Function`
+- `AsyncFunction`
+- `Event`
+- `View`
+- `ViewEvent`
+- `SharedObject`
+
+Important behaviors:
+
+- no features selected means a minimal module
+- in interactive mode, feature examples start unselected
+- in non-interactive mode, no features are included unless `--features` or `--full-example` is passed
+- `--full-example` is equivalent to `--features all`
+- `ViewEvent` automatically includes `View`
+
+Use `View` only when the module actually renders UI. For native-only modules, do not scaffold the view files unless you plan to use them.
+
+## Local Module Quirks
+
+- local modules do not generate an `index.ts` barrel by default
+- use `--barrel` only if you want a root barrel file
+- local modules skip dependency installation and do not create an `example` app
+- local modules do not have a local `package.json`; they rely on the host app
+
+If `--barrel` is not used, the CLI's follow-up instructions point to direct imports from the module's `src/` files.
+
+## Standalone Module Quirks
+
+- `--package-manager` is only relevant for standalone modules
+- if omitted, the CLI detects the package manager from the user agent or available package managers
+- the scaffold builds TypeScript after installing dependencies
+- the `example` app is created only when examples are enabled; `--no-example` skips it
+- `--with-readme` and `--with-changelog` opt into those files
+
+The generated standalone scripts include `build`, `clean`, `test`, `prepare`, `open:ios`, and `open:android`.
+
+## add-platform-support
+
+Use this subcommand when an existing Expo module needs another supported platform.
+
+Interactive usage from the module root:
+
+```bash
+npx create-expo-module@latest add-platform-support
+```
+
+Explicit usage:
+
+```bash
+npx create-expo-module@latest add-platform-support --platform android
+```
+
+You can also pass the module path:
+
+```bash
+npx create-expo-module@latest add-platform-support ./packages/expo-key-value-store --platform web
+```
+
+Important behaviors:
+
+- supported values are `apple`, `android`, and `web`
+- in non-interactive mode, `--platform` is required
+- the command only adds platforms that are not already present in `expo-module.config.json`
+- it refuses to overwrite existing `android/` or `ios/` directories
+- for native modules, it only works with modules that use the Expo Modules API DSL
+- older module formats are not supported
+
+### Feature detection
+
+`add-platform-support` tries to detect the existing module's feature examples from the native module definition. This is best effort.
+
+Use `--features` to override the detected feature examples when:
+
+- the module is unusual
+- the module uses generated code
+- the definition is spread across multiple files
+- the generated files do not match the existing module's shape
+
+If no features are detected or provided, the command creates a minimal scaffold for the new platform.
+
+## Environment Variables
+
+- `EXPO_BETA`: use the next template version
+- `EXPO_DEBUG`: enable debug logs
+- `EXPO_NO_TELEMETRY`: disable telemetry
+- `EXPO_NONINTERACTIVE`: force non-interactive mode

--- a/plugins/expo/skills/expo-module/references/create-expo-module.md
+++ b/plugins/expo/skills/expo-module/references/create-expo-module.md
@@ -40,7 +40,7 @@ npx create-expo-module@latest key-value-store --local --platform apple android -
 If you need deterministic non-interactive output, pass the slug or path explicitly and then pass the rest of the options:
 
 ```bash
-CI=1 npx create-expo-module@latest key-value-store \
+EXPO_NONINTERACTIVE=1 npx create-expo-module@latest key-value-store \
   --local \
   --name KeyValueStore \
   --package expo.modules.keyvaluestore \
@@ -63,28 +63,28 @@ npx create-expo-module@latest expo-key-value-store --platform apple android --fe
 
 These are the module creation options exposed by the CLI:
 
-| Option | Applies to | Notes |
-| --- | --- | --- |
-| `[path]` | local, standalone | Positional slug or target path. Use this explicitly for stable local scaffolding in non-interactive mode. |
-| `--local` | local | Create a local module inside the current Expo project. |
-| `--platform <platforms...>` | local, standalone | Valid values: `apple`, `android`, `web`. |
-| `--features <features...>` | local, standalone | Pick generated feature examples. Use `all` to include everything. |
-| `--full-example` | local, standalone | Equivalent to `--features all`. |
-| `--barrel` | local | Generate a local `index.ts` barrel. Ignored for standalone modules. |
-| `--source <source_dir>` | local, standalone | Use a local `expo-module-template` directory instead of downloading from npm. |
-| `--name <name>` | local, standalone | Native module name, for example `KeyValueStore`. |
-| `--description <description>` | standalone | Package description. |
-| `--package <package>` | local, standalone | Android package name, for example `expo.modules.keyvaluestore`. |
-| `--author-name <name>` | standalone | Package author name. |
-| `--author-email <email>` | standalone | Package author email. |
-| `--author-url <url>` | standalone | Package author profile URL. |
-| `--repo <url>` | standalone | Package repository URL. |
-| `--license <license>` | standalone | Package license identifier. |
-| `--module-version <version>` | standalone | Initial package version. |
-| `--package-manager <manager>` | standalone | One of `npm`, `pnpm`, `yarn`, `bun`. |
-| `--with-readme` | standalone | Keep `README.md` in the generated package. |
-| `--with-changelog` | standalone | Keep `CHANGELOG.md` in the generated package. |
-| `--no-example` | standalone | Skip creating the example app. |
+| Option                        | Applies to        | Notes                                                                                                     |
+| ----------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------- |
+| `[path]`                      | local, standalone | Positional slug or target path. Use this explicitly for stable local scaffolding in non-interactive mode. |
+| `--local`                     | local             | Create a local module inside the current Expo project.                                                    |
+| `--platform <platforms...>`   | local, standalone | Valid values: `apple`, `android`, `web`.                                                                  |
+| `--features <features...>`    | local, standalone | Pick generated feature examples. Use `all` to include everything.                                         |
+| `--full-example`              | local, standalone | Equivalent to `--features all`.                                                                           |
+| `--barrel`                    | local             | Generate a local `index.ts` barrel. Ignored for standalone modules.                                       |
+| `--source <source_dir>`       | local, standalone | Use a local `expo-module-template` directory instead of downloading from npm.                             |
+| `--name <name>`               | local, standalone | Native module name, for example `KeyValueStore`.                                                          |
+| `--description <description>` | standalone        | Package description.                                                                                      |
+| `--package <package>`         | local, standalone | Android package name, for example `expo.modules.keyvaluestore`.                                           |
+| `--author-name <name>`        | standalone        | Package author name.                                                                                      |
+| `--author-email <email>`      | standalone        | Package author email.                                                                                     |
+| `--author-url <url>`          | standalone        | Package author profile URL.                                                                               |
+| `--repo <url>`                | standalone        | Package repository URL.                                                                                   |
+| `--license <license>`         | standalone        | Package license identifier.                                                                               |
+| `--module-version <version>`  | standalone        | Initial package version.                                                                                  |
+| `--package-manager <manager>` | standalone        | One of `npm`, `pnpm`, `yarn`, `bun`.                                                                      |
+| `--with-readme`               | standalone        | Keep `README.md` in the generated package.                                                                |
+| `--with-changelog`            | standalone        | Keep `CHANGELOG.md` in the generated package.                                                             |
+| `--no-example`                | standalone        | Skip creating the example app.                                                                            |
 
 Notes:
 
@@ -203,3 +203,4 @@ If no features are detected or provided, the command creates a minimal scaffold 
 - `EXPO_DEBUG`: enable debug logs
 - `EXPO_NO_TELEMETRY`: disable telemetry
 - `EXPO_NONINTERACTIVE`: force non-interactive mode
+- `CI`: same as `EXPO_NONINTERACTIVE`, used in CI environments

--- a/plugins/expo/skills/expo-module/references/module-config.md
+++ b/plugins/expo/skills/expo-module/references/module-config.md
@@ -2,7 +2,14 @@
 
 ## expo-module.config.json
 
-Required for autolinking. Must be adjacent to `package.json`.
+Use `expo-module.config.json` for autolinking and module registration.
+
+File placement depends on the module type:
+
+- **standalone module**: place it at the package root, next to `package.json`
+- **local module**: place it at the module root inside the app's local modules directory (`expo.autolinking.nativeModulesDir`, or `modules/` by default)
+
+Example:
 
 ```json
 {
@@ -21,7 +28,7 @@ Required for autolinking. Must be adjacent to `package.json`.
 
 | Field | Description |
 |-------|-------------|
-| `platforms` | Array: `"android"`, `"apple"` (or `"ios"`, `"macos"`, `"tvos"`), `"web"`, `"devtools"` |
+| `platforms` | Array of supported platforms. Valid values include `android`, `apple`, `web`, and `devtools`. You can also use granular Apple platforms such as `ios`, `macos`, and `tvos`, but `apple` is preferred when one Swift module supports multiple Apple targets. |
 | `apple.modules` | Swift module class names |
 | `apple.appDelegateSubscribers` | Swift AppDelegate subscriber class names |
 | `android.modules` | Fully-qualified Kotlin module class names (package + class) |
@@ -29,6 +36,9 @@ Required for autolinking. Must be adjacent to `package.json`.
 ## Autolinking
 
 Expo autolinking automatically discovers and links modules that have `expo-module.config.json`. No manual native project configuration needed — install via npm, run `pod install`.
+
+- standalone modules are resolved from dependencies and search paths.
+- local modules are resolved from the `modules` directory or `nativeModulesDir` if defined.
 
 ### Resolution Order
 


### PR DESCRIPTION
# Why

There is a lot of new changes in `create-expo-module`, we need to update the skill accordingly

# How

Add a reference file for `create-expo-module` 

# Test Plan

Tested by installing the skill locally and asking an agent to create an expo module. Looks like it its working good.

# Important

This skill includes information that will not be relevant until SDK-56 is published so we should correctly time when this change is published. 