### PR TITLE
fix(expo-ui-swift-ui): correct import path from @expo-ui/swift-ui to @expo/ui/swift-ui

### DIFF
--- a/plugins/expo/skills/expo-ui-swift-ui/SKILL.md
+++ b/plugins/expo/skills/expo-ui-swift-ui/SKILL.md
@@ -23,7 +23,7 @@ A native rebuild is required after installation (`npx expo run:ios`).
 - `RNHostView` is specifically for embedding RN components inside a SwiftUI tree. Example:
 
 ```jsx
-import { Host, VStack, RNHostView } from "@expo-ui/swift-ui";
+import { Host, VStack, RNHostView } from "@expo/ui/swift-ui";
 import { Pressable } from "react-native";
 
 <Host matchContents>


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

The code example in `plugins/expo/skills/expo-ui-swift-ui/SKILL.md` (line 27) imports from `@expo-ui/swift-ui`, but the frontmatter description and install instructions consistently reference `@expo/ui/swift-ui`. These are different package paths — `@expo-ui/swift-ui` does not exist as a published package, so any developer copying the example import verbatim will get a `Cannot find module` error at runtime.

**Fix**: Change the import path in the code example to match the correct package path used everywhere else in the file.

```diff
-import { Host, VStack, RNHostView } from "@expo-ui/swift-ui";
+import { Host, VStack, RNHostView } from "@expo/ui/swift-ui";
```

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-broken-reference","fingerprint":"sha256:0104077816854fea5da4278eb03ba2d6ffc770661839f1a7d1d4b8bb9214bc7c"}]}
nlpm-metadata-end -->