### PR TITLE
fix(expo-deployment): unify reference paths to ./references/ (plural)

### DIFF
--- a/plugins/expo/skills/expo-deployment/SKILL.md
+++ b/plugins/expo/skills/expo-deployment/SKILL.md
@@ -120,20 +120,20 @@ Standard `eas.json` for production deployments:
 
 - Use `npx testflight` for quick TestFlight submissions
 - Configure Apple credentials via `eas credentials`
-- See ./reference/testflight.md for credential setup
-- See ./reference/ios-app-store.md for App Store submission
+- See ./references/testflight.md for credential setup
+- See ./references/ios-app-store.md for App Store submission
 
 ### Android
 
 - Set up Google Play Console service account
 - Configure tracks: internal → closed → open → production
-- See ./reference/play-store.md for detailed setup
+- See ./references/play-store.md for detailed setup
 
 ### Web
 
 - EAS Hosting provides preview URLs for PRs
 - Production deploys to your custom domain
-- See ./reference/workflows.md for CI/CD automation
+- See ./references/workflows.md for CI/CD automation
 
 ## Automated Deployments
 
@@ -162,7 +162,7 @@ jobs:
       profile: production
 ```
 
-See ./reference/workflows.md for more workflow examples.
+See ./references/workflows.md for more workflow examples.
 
 ## Version Management
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`plugins/expo/skills/expo-deployment/SKILL.md` has an inconsistency in its reference paths. The top-level **References** section (lines 16–20) correctly uses `./references/` (plural), but five in-body `See …` links use `./reference/` (singular):

- Line 123: `See ./reference/testflight.md`
- Line 124: `See ./reference/ios-app-store.md`
- Line 130: `See ./reference/play-store.md`
- Line 136: `See ./reference/workflows.md`
- Line 165: `See ./reference/workflows.md`

The `references/` directory exists; `reference/` does not. Claude follows these links to fetch supplementary docs at load time — the singular-form links silently resolve to nothing, making half the contextual references unreachable.

**Fix**: Replace all `./reference/` occurrences in the body text with `./references/` to match the actual directory name and the top-level References section.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-broken-reference","fingerprint":"sha256:9b998147e7c2d3937ce0d6536023a6170713099be5cc83df15351e40551a5914"}]}
nlpm-metadata-end -->