### PR TITLE
fix(expo-cicd-workflows): add URL allowlist to fetch.js to prevent SSRF

### DIFF
--- a/plugins/expo/skills/expo-cicd-workflows/scripts/fetch.js
+++ b/plugins/expo/skills/expo-cicd-workflows/scripts/fetch.js
@@ -92,6 +92,20 @@ function parseMaxAge(cacheControl) {
   return match ? parseInt(match[1], 10) : null;
 }
 
+const ALLOWED_URL_PREFIXES = [
+  'https://api.expo.dev/',
+  'https://raw.githubusercontent.com/expo/',
+  'https://docs.expo.dev/',
+];
+
+function assertAllowedUrl(url) {
+  if (!ALLOWED_URL_PREFIXES.some((prefix) => url.startsWith(prefix))) {
+    throw new Error(
+      `URL not permitted. Allowed prefixes:\n${ALLOWED_URL_PREFIXES.map((p) => `  ${p}`).join('\n')}`
+    );
+  }
+}
+
 if (import.meta.main) {
   const url = process.argv[2];
 
@@ -104,6 +118,7 @@ Cache is stored in: ${CACHE_DIRECTORY}/`);
     process.exit(url ? 0 : 1);
   }
 
+  assertAllowedUrl(url);
   const data = await fetchCached(url);
   console.log(data);
 }


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Fix (Medium)

`plugins/expo/skills/expo-cicd-workflows/scripts/fetch.js` accepts any URL via `process.argv[2]` and passes it directly to `fetch()` without validating the scheme or domain (lines 96–107). If the script is ever invoked with attacker-controlled input outside the documented skill context, an adversary could supply an arbitrary URL — including internal metadata endpoints like `http://169.254.169.254/` — triggering a Server-Side Request Forgery (SSRF).

**Fix**: Add a `ALLOWED_URL_PREFIXES` array containing the URLs this script legitimately needs (`https://api.expo.dev/`, `https://raw.githubusercontent.com/expo/`, `https://docs.expo.dev/`) and a guard function `assertAllowedUrl()` that rejects any URL not matching those prefixes. The guard is called immediately after the argument is validated, before any network request is made.

This is a defence-in-depth improvement. The practical risk within the skill context is low, but the fix costs nothing and makes the script's intended scope explicit.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-path-traversal","fingerprint":"sha256:f47a9d7facb678fe7e153596857104e6ddae56d8454fe7e73ed876b85d650e76"}]}
nlpm-metadata-end -->