### PR TITLE
fix(expo-cicd-workflows): pin dependency versions to exact semver in package.json

### DIFF
--- a/plugins/expo/skills/expo-cicd-workflows/scripts/package.json
+++ b/plugins/expo/skills/expo-cicd-workflows/scripts/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "ajv": "^8.17.1",
-    "ajv-formats": "^3.0.1",
-    "js-yaml": "^4.1.0"
+    "ajv": "8.17.1",
+    "ajv-formats": "3.0.1",
+    "js-yaml": "4.1.0"
   }
 }


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Fix (Low — Supply Chain Hygiene)

`plugins/expo/skills/expo-cicd-workflows/scripts/package.json` specifies all three dependencies with caret (`^`) semver ranges:

```json
"ajv": "^8.17.1",
"ajv-formats": "^3.0.1",
"js-yaml": "^4.1.0"
```

Caret ranges allow automatic minor and patch upgrades. Without a committed lockfile, any fresh `npm install` can pull in a newer version — including one that has been supply-chain-compromised. Pinning to exact versions makes the resolved version explicit and auditable regardless of whether a lockfile is present.

**Fix**: Remove the `^` prefix from all three dependencies, pinning them to the versions already in use.

```json
"ajv": "8.17.1",
"ajv-formats": "3.0.1",
"js-yaml": "4.1.0"
```

Intentional upgrades can still be performed via `npm install ajv@latest` followed by a review and re-pin — this PR simply makes the current resolved version the default.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-unpinned-semver","fingerprint":"sha256:f8633462e204588abfd583d28cb36a58524016e65406500863f1a397b5477af9"},{"rule_id":"SEC-unpinned-semver","fingerprint":"sha256:62585b63b2e4ee7259e6a97a87a868074639d6aa67c15233604d02ea9848ae5e"},{"rule_id":"SEC-unpinned-semver","fingerprint":"sha256:c78e33eb7db6d729f133072f899827b019ce69b9021097d4e1aa466218293b91"}]}
nlpm-metadata-end -->