### PR TITLE
Update UI skill names to match agent skill spec

### DIFF
--- a/plugins/expo/skills/expo-ui-jetpack-compose/SKILL.md
+++ b/plugins/expo/skills/expo-ui-jetpack-compose/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Expo UI Jetpack Compose
+name: expo-ui-jetpack-compose
 description: "`@expo/ui/jetpack-compose` package lets you use Jetpack Compose Views and modifiers in your app."
 ---
 

--- a/plugins/expo/skills/expo-ui-swift-ui/SKILL.md
+++ b/plugins/expo/skills/expo-ui-swift-ui/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Expo UI SwiftUI
+name: expo-ui-swift-ui
 description: "`@expo/ui/swift-ui` package lets you use SwiftUI Views and modifiers in your app."
 ---
 


### PR DESCRIPTION
"Expo UI Jetpack Compose" and "Expo UI SwiftUI" names do not match the spec for agent skills (https://agentskills.io/specification#name-field).

Updates the name field in each skill to match the parent directory and the agent skill spec. This also brings these into line with the other Expo skills.