### PR TITLE
Update upgrading-expo skill with iOS deployment target

### DIFF
--- a/plugins/expo/skills/upgrading-expo/SKILL.md
+++ b/plugins/expo/skills/upgrading-expo/SKILL.md
@@ -76,6 +76,7 @@ These steps only apply when `ios/` and/or `android/` directories exist in the pr
 
 - Review release notes for the target SDK version at https://expo.dev/changelog
 - If using Expo SDK 54 or later, ensure react-native-worklets is installed — this is required for react-native-reanimated to work.
+- Check for a raised minimum iOS deployment target and update it in `ios/Podfile` (`platform :ios, 'X.X'`) and Xcode Build Settings (`IPHONEOS_DEPLOYMENT_TARGET`), or via `expo-build-properties` in app.json for CNG projects
 - Enable React Compiler in SDK 54+ by adding `"experiments": { "reactCompiler": true }` to app.json — it's stable and recommended
 - Delete sdkVersion from `app.json` to let Expo manage it automatically
 - Remove implicit packages from `package.json`: `@babel/core`, `babel-preset-expo`, `expo-constants`.
@@ -106,6 +107,7 @@ Check if package.json has excluded packages:
 ```
 
 Exclusions are often workarounds that may no longer be needed after upgrading. Review each one.
+
 ## Removing patches
 
 Check if there are any outdated patches in the `patches/` directory. Remove them if they are no longer needed.


### PR DESCRIPTION
Upgrading Expo (and potentially the corresponding RN upgrade) often requires a higher minimum target version.

For Expo 55 -> 56, our app was at 15.1 and required 16.4.

```
[!] CocoaPods could not find compatible versions for pod "Expo":
  In Podfile:
    Expo (from `../node_modules/expo`)
Specs satisfying the `Expo (from `../node_modules/expo`)` dependency were found, but they required a higher minimum deployment target.

[!] [Expo] @expo/log-box was not linked: requires iOS 16.4 but app targets 15.1
```

This PR updates the upgrading-expo skill to handle this. 