### PR TITLE
fine tune wordings

### DIFF
--- a/plugins/expo/.mcp.json
+++ b/plugins/expo/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "expo-mcp": {
+    "expo": {
       "type": "http",
       "url": "https://mcp.expo.dev/mcp"
     }

--- a/plugins/expo/skills/eas-update-insights/SKILL.md
+++ b/plugins/expo/skills/eas-update-insights/SKILL.md
@@ -226,4 +226,3 @@ Human-readable group details plus 30 days of launches/failures per platform — 
 - **Fresh publishes** may show zeros for a short period while the metrics pipeline catches up.
 - **Installs are downloads, not launches**: the `installs` / "Launches" field counts users who downloaded the manifest and launch asset. A confirmed run only registers on the user's *next* update check (typically up to 24h later, depending on the app's update policy). So metrics lag the real-world state slightly.
 - **Crashes are self-reported**: `failedInstalls` / "Crashes" counts updates that errored during install/launch and were reported on the next update check. Crashes that don't trigger an update request (e.g. process kill before recovery) won't appear.
-

--- a/plugins/expo/skills/expo-module/SKILL.md
+++ b/plugins/expo/skills/expo-module/SKILL.md
@@ -52,11 +52,11 @@ See [references/create-expo-module.md](references/create-expo-module.md) before 
    - **Standalone module** for reuse, monorepos, or publishing
 2. Determine native `expo-module` features that you will need.
    - Based on the user's instructions determine which feature scaffolding will be useful.
-   - Available features: `Constant`, `Function`, `AsyncFunction`, `Event`, `View`,`ViewEvent`, `SharedObject`
+   - Available features: `Constant`, `Function`, `AsyncFunction`, `Event`, `View`, `ViewEvent`, `SharedObject`
 3. Scaffold deliberately:
    - pass an explicit slug or path
    - choose `--platform` intentionally instead of relying on defaults
-   - use `--features` to choose code samples which you will modify in the next stepto match the real implementation.
+   - use `--features` to choose code samples which you will modify in the next step to match the real implementation.
 4. Replace generated example code with the real implementation.
 5. If you add a new platform later, prefer `add-platform-support` over manual file copying.
 


### PR DESCRIPTION
fix typo and fine tune wordings. also rename expo-mcp to just expo