### PR TITLE
bump plugin version to 1.1.0 to ship skill updates

### DIFF
--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",


### PR DESCRIPTION
## Why

The `version` field in the Expo plugin manifests has stayed at `1.0.0` across every commit since the plugin first shipped, even as skills were added and refined (`expo-observe`, `add-app-clip`, brownfield + module refinements).

Claude Code's plugin update check keys "is there a newer version?" off the **manifest `version` string**, not the marketplace's pinned commit SHA. So even though `anthropics/claude-plugins-official` advances its `git-subdir` SHA pin to our latest `main`, installed clients short-circuit with "already at latest 1.0.0" and never re-pull. Result: users sit on stale skill content indefinitely.

Bumping to `1.1.0` is the trigger that makes installed clients detect an update and pull the current `main`.

## What

Bump `version` `1.0.0` → `1.1.0` in all three plugin manifests, kept in lockstep:
- `plugins/expo/.claude-plugin/plugin.json`
- `plugins/expo/.codex-plugin/plugin.json`
- `plugins/expo/.cursor-plugin/plugin.json`

Minor bump because new skills have accumulated under the static `1.0.0` tag since the last effective release.

## Follow-up / process

- After merge, the marketplace SHA pin in `anthropics/claude-plugins-official` must advance to a commit at/after this bump for clients to see `1.1.0`. We should confirm whether that pin is bot-advanced on push to `main` or needs a manual PR from us.
- **Going forward: bump `version` in the same PR as any skill content change.** That is the only signal that propagates an update to installed clients.