### PR TITLE
add plugin version bump check

### DIFF
--- a/.github/workflows/plugin-version-bump.yml
+++ b/.github/workflows/plugin-version-bump.yml
@@ -15,7 +15,6 @@ concurrency:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
 
 jobs:
   check:
@@ -28,12 +27,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Check plugin version bump
         id: version-check
         continue-on-error: true
         env:
           VERSION_CHECK_SUMMARY_PATH: .context/plugin-version-check-summary.md
-        run: node scripts/check-plugin-version-bump.mjs origin/main
+        run: bun scripts/check-plugin-version-bump.ts origin/main
 
       - name: Add workflow summary
         if: always() && hashFiles('.context/plugin-version-check-summary.md') != ''

--- a/.github/workflows/plugin-version-bump.yml
+++ b/.github/workflows/plugin-version-bump.yml
@@ -1,0 +1,84 @@
+name: plugin version bump
+
+on:
+  pull_request:
+    branches:
+      - main
+  merge_group:
+    branches:
+      - main
+
+concurrency:
+  group: plugin-version-bump-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  check:
+    name: check Expo plugin versions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check plugin version bump
+        id: version-check
+        continue-on-error: true
+        env:
+          VERSION_CHECK_SUMMARY_PATH: .context/plugin-version-check-summary.md
+        run: node scripts/check-plugin-version-bump.mjs origin/main
+
+      - name: Add workflow summary
+        if: always() && hashFiles('.context/plugin-version-check-summary.md') != ''
+        run: cat .context/plugin-version-check-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on pull request
+        if: always() && github.event_name == 'pull_request' && hashFiles('.context/plugin-version-check-summary.md') != ''
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("node:fs");
+
+            const marker = "<!-- expo-plugin-version-check -->";
+            const summary = fs.readFileSync(".context/plugin-version-check-summary.md", "utf8");
+            const body = `${marker}\n${summary}`;
+            const issue_number = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existingComment = comments.find(
+              (comment) => comment.user?.type === "Bot" && comment.body?.includes(marker)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: Fail on invalid plugin versions
+        if: steps.version-check.outcome == 'failure'
+        run: exit 1

--- a/scripts/check-plugin-version-bump.mjs
+++ b/scripts/check-plugin-version-bump.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+const baseRef = process.argv[2] ?? "origin/main";
+
+const pluginManifests = [
+  {
+    label: "Claude",
+    path: "plugins/expo/.claude-plugin/plugin.json",
+  },
+  {
+    label: "Codex",
+    path: "plugins/expo/.codex-plugin/plugin.json",
+  },
+  {
+    label: "Cursor",
+    path: "plugins/expo/.cursor-plugin/plugin.json",
+  },
+];
+
+const versionedPluginPaths = [
+  "plugins/expo/skills/",
+  "plugins/expo/.claude-plugin/plugin.json",
+  "plugins/expo/.codex-plugin/plugin.json",
+  "plugins/expo/.cursor-plugin/plugin.json",
+  "plugins/expo/.mcp.json",
+  "plugins/expo/mcp.json",
+];
+
+function runGit(args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function getChangedFiles() {
+  const output = runGit(["diff", "--name-only", `${baseRef}...HEAD`]);
+  return output ? output.split("\n") : [];
+}
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function readBaseJson(path) {
+  try {
+    return JSON.parse(runGit(["show", `${baseRef}:${path}`]));
+  } catch {
+    return null;
+  }
+}
+
+function parseSemver(version) {
+  if (typeof version !== "string") {
+    return null;
+  }
+
+  const match = version.match(
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/
+  );
+
+  if (!match) {
+    return null;
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4]?.split(".") ?? [],
+  };
+}
+
+function compareIdentifiers(left, right) {
+  const leftIsNumeric = /^\d+$/.test(left);
+  const rightIsNumeric = /^\d+$/.test(right);
+
+  if (leftIsNumeric && rightIsNumeric) {
+    return Number(left) - Number(right);
+  }
+
+  if (leftIsNumeric) {
+    return -1;
+  }
+
+  if (rightIsNumeric) {
+    return 1;
+  }
+
+  if (left < right) {
+    return -1;
+  }
+
+  if (left > right) {
+    return 1;
+  }
+
+  return 0;
+}
+
+function compareSemver(leftVersion, rightVersion) {
+  const left = parseSemver(leftVersion);
+  const right = parseSemver(rightVersion);
+
+  if (!left || !right) {
+    throw new Error(`Cannot compare invalid semver values: ${leftVersion}, ${rightVersion}`);
+  }
+
+  for (const field of ["major", "minor", "patch"]) {
+    if (left[field] !== right[field]) {
+      return left[field] - right[field];
+    }
+  }
+
+  if (left.prerelease.length === 0 && right.prerelease.length === 0) {
+    return 0;
+  }
+
+  if (left.prerelease.length === 0) {
+    return 1;
+  }
+
+  if (right.prerelease.length === 0) {
+    return -1;
+  }
+
+  const length = Math.max(left.prerelease.length, right.prerelease.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = left.prerelease[index];
+    const rightPart = right.prerelease[index];
+
+    if (leftPart === undefined) {
+      return -1;
+    }
+
+    if (rightPart === undefined) {
+      return 1;
+    }
+
+    const comparison = compareIdentifiers(leftPart, rightPart);
+    if (comparison !== 0) {
+      return comparison;
+    }
+  }
+
+  return 0;
+}
+
+function hasVersionedPluginChange(path) {
+  return versionedPluginPaths.some((entry) =>
+    entry.endsWith("/") ? path.startsWith(entry) : path === entry
+  );
+}
+
+function formatVersionRows(rows) {
+  return [
+    "| Plugin | main | PR |",
+    "| --- | --- | --- |",
+    ...rows.map((row) => `| ${row.label} | ${row.baseVersion ?? "—"} | ${row.currentVersion ?? "—"} |`),
+  ].join("\n");
+}
+
+function writeSummary(markdown) {
+  const summaryPath = process.env.VERSION_CHECK_SUMMARY_PATH;
+  if (!summaryPath) {
+    return;
+  }
+
+  mkdirSync(dirname(summaryPath), { recursive: true });
+  writeFileSync(summaryPath, `${markdown}\n`);
+}
+
+function complete(success, markdown) {
+  writeSummary(markdown);
+  console.log(markdown);
+  process.exit(success ? 0 : 1);
+}
+
+const changedFiles = getChangedFiles();
+const versionedChanges = changedFiles.filter(hasVersionedPluginChange);
+
+if (versionedChanges.length === 0) {
+  complete(
+    true,
+    [
+      "## Expo plugin version check",
+      "",
+      "No versioned Expo plugin or skill files changed, so no plugin version bump is required.",
+    ].join("\n")
+  );
+}
+
+const rows = pluginManifests.map((manifest) => ({
+  ...manifest,
+  baseVersion: readBaseJson(manifest.path)?.version,
+  currentVersion: readJson(manifest.path)?.version,
+}));
+
+const errors = [];
+const currentVersions = new Set(rows.map((row) => row.currentVersion));
+const baseVersions = new Set(rows.map((row) => row.baseVersion));
+
+for (const row of rows) {
+  if (row.baseVersion === undefined) {
+    errors.push(`${row.label} manifest is missing or has no version on main (${row.path}).`);
+  } else if (!parseSemver(row.baseVersion)) {
+    errors.push(`${row.label} has an invalid semver version on main: ${row.baseVersion}`);
+  }
+
+  if (row.currentVersion === undefined) {
+    errors.push(`${row.label} manifest is missing or has no version in this PR (${row.path}).`);
+  } else if (!parseSemver(row.currentVersion)) {
+    errors.push(`${row.label} has an invalid semver version in this PR: ${row.currentVersion}`);
+  }
+}
+
+if (baseVersions.size !== 1) {
+  errors.push("The Claude, Codex, and Cursor plugin versions on main are not in sync.");
+}
+
+if (currentVersions.size !== 1) {
+  errors.push("The Claude, Codex, and Cursor plugin versions in this PR must match.");
+}
+
+if (errors.length === 0) {
+  for (const row of rows) {
+    if (compareSemver(row.currentVersion, row.baseVersion) <= 0) {
+      errors.push(`${row.label} version must be greater than main (${row.baseVersion}).`);
+    }
+  }
+}
+
+const changedList = versionedChanges.map((path) => `- \`${path}\``).join("\n");
+const markdown = [
+  "## Expo plugin version check",
+  "",
+  errors.length === 0
+    ? "Passed. Versioned Expo plugin files changed and all plugin manifests were bumped together."
+    : "Failed. Versioned Expo plugin files changed, so the Claude, Codex, and Cursor plugin manifests must all be bumped together.",
+  "",
+  formatVersionRows(rows),
+  "",
+  "Changed versioned files:",
+  "",
+  changedList,
+  ...(errors.length === 0 ? [] : ["", "Required fixes:", "", ...errors.map((error) => `- ${error}`)]),
+].join("\n");
+
+complete(errors.length === 0, markdown);

--- a/scripts/check-plugin-version-bump.ts
+++ b/scripts/check-plugin-version-bump.ts
@@ -1,12 +1,23 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 
 import { execFileSync } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
+import { semver } from "bun";
+
+type PluginManifest = {
+  label: string;
+  path: string;
+};
+
+type VersionRow = PluginManifest & {
+  baseVersion: unknown;
+  currentVersion: unknown;
+};
 
 const baseRef = process.argv[2] ?? "origin/main";
 
-const pluginManifests = [
+const pluginManifests: PluginManifest[] = [
   {
     label: "Claude",
     path: "plugins/expo/.claude-plugin/plugin.json",
@@ -30,7 +41,7 @@ const versionedPluginPaths = [
   "plugins/expo/mcp.json",
 ];
 
-function runGit(args) {
+function runGit(args: string[]) {
   return execFileSync("git", args, { encoding: "utf8" }).trim();
 }
 
@@ -39,7 +50,7 @@ function getChangedFiles() {
   return output ? output.split("\n") : [];
 }
 
-function readJson(path) {
+function readJson(path: string) {
   try {
     return JSON.parse(readFileSync(path, "utf8"));
   } catch {
@@ -47,7 +58,7 @@ function readJson(path) {
   }
 }
 
-function readBaseJson(path) {
+function readBaseJson(path: string) {
   try {
     return JSON.parse(runGit(["show", `${baseRef}:${path}`]));
   } catch {
@@ -55,117 +66,37 @@ function readBaseJson(path) {
   }
 }
 
-function parseSemver(version) {
+function isSemver(version: unknown): version is string {
   if (typeof version !== "string") {
-    return null;
+    return false;
   }
 
-  const match = version.match(
-    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/
-  );
-
-  if (!match) {
-    return null;
+  try {
+    return semver.satisfies(version, version);
+  } catch {
+    return false;
   }
-
-  return {
-    major: Number(match[1]),
-    minor: Number(match[2]),
-    patch: Number(match[3]),
-    prerelease: match[4]?.split(".") ?? [],
-  };
 }
 
-function compareIdentifiers(left, right) {
-  const leftIsNumeric = /^\d+$/.test(left);
-  const rightIsNumeric = /^\d+$/.test(right);
-
-  if (leftIsNumeric && rightIsNumeric) {
-    return Number(left) - Number(right);
-  }
-
-  if (leftIsNumeric) {
-    return -1;
-  }
-
-  if (rightIsNumeric) {
-    return 1;
-  }
-
-  if (left < right) {
-    return -1;
-  }
-
-  if (left > right) {
-    return 1;
-  }
-
-  return 0;
-}
-
-function compareSemver(leftVersion, rightVersion) {
-  const left = parseSemver(leftVersion);
-  const right = parseSemver(rightVersion);
-
-  if (!left || !right) {
-    throw new Error(`Cannot compare invalid semver values: ${leftVersion}, ${rightVersion}`);
-  }
-
-  for (const field of ["major", "minor", "patch"]) {
-    if (left[field] !== right[field]) {
-      return left[field] - right[field];
-    }
-  }
-
-  if (left.prerelease.length === 0 && right.prerelease.length === 0) {
-    return 0;
-  }
-
-  if (left.prerelease.length === 0) {
-    return 1;
-  }
-
-  if (right.prerelease.length === 0) {
-    return -1;
-  }
-
-  const length = Math.max(left.prerelease.length, right.prerelease.length);
-  for (let index = 0; index < length; index += 1) {
-    const leftPart = left.prerelease[index];
-    const rightPart = right.prerelease[index];
-
-    if (leftPart === undefined) {
-      return -1;
-    }
-
-    if (rightPart === undefined) {
-      return 1;
-    }
-
-    const comparison = compareIdentifiers(leftPart, rightPart);
-    if (comparison !== 0) {
-      return comparison;
-    }
-  }
-
-  return 0;
-}
-
-function hasVersionedPluginChange(path) {
+function hasVersionedPluginChange(path: string) {
   return versionedPluginPaths.some((entry) =>
     entry.endsWith("/") ? path.startsWith(entry) : path === entry
   );
 }
 
-function formatVersionRows(rows) {
+function formatVersion(version: unknown) {
+  return typeof version === "string" ? version : "—";
+}
+
+function formatVersionRows(rows: VersionRow[]) {
   return [
     "| Plugin | main | PR |",
     "| --- | --- | --- |",
-    ...rows.map((row) => `| ${row.label} | ${row.baseVersion ?? "—"} | ${row.currentVersion ?? "—"} |`),
+    ...rows.map((row) => `| ${row.label} | ${formatVersion(row.baseVersion)} | ${formatVersion(row.currentVersion)} |`),
   ].join("\n");
 }
 
-function writeSummary(markdown) {
+function writeSummary(markdown: string) {
   const summaryPath = process.env.VERSION_CHECK_SUMMARY_PATH;
   if (!summaryPath) {
     return;
@@ -175,7 +106,7 @@ function writeSummary(markdown) {
   writeFileSync(summaryPath, `${markdown}\n`);
 }
 
-function complete(success, markdown) {
+function complete(success: boolean, markdown: string): never {
   writeSummary(markdown);
   console.log(markdown);
   process.exit(success ? 0 : 1);
@@ -195,27 +126,27 @@ if (versionedChanges.length === 0) {
   );
 }
 
-const rows = pluginManifests.map((manifest) => ({
+const rows: VersionRow[] = pluginManifests.map((manifest) => ({
   ...manifest,
   baseVersion: readBaseJson(manifest.path)?.version,
   currentVersion: readJson(manifest.path)?.version,
 }));
 
-const errors = [];
+const errors: string[] = [];
 const currentVersions = new Set(rows.map((row) => row.currentVersion));
 const baseVersions = new Set(rows.map((row) => row.baseVersion));
 
 for (const row of rows) {
   if (row.baseVersion === undefined) {
     errors.push(`${row.label} manifest is missing or has no version on main (${row.path}).`);
-  } else if (!parseSemver(row.baseVersion)) {
-    errors.push(`${row.label} has an invalid semver version on main: ${row.baseVersion}`);
+  } else if (!isSemver(row.baseVersion)) {
+    errors.push(`${row.label} has an invalid semver version on main: ${formatVersion(row.baseVersion)}`);
   }
 
   if (row.currentVersion === undefined) {
     errors.push(`${row.label} manifest is missing or has no version in this PR (${row.path}).`);
-  } else if (!parseSemver(row.currentVersion)) {
-    errors.push(`${row.label} has an invalid semver version in this PR: ${row.currentVersion}`);
+  } else if (!isSemver(row.currentVersion)) {
+    errors.push(`${row.label} has an invalid semver version in this PR: ${formatVersion(row.currentVersion)}`);
   }
 }
 
@@ -229,8 +160,8 @@ if (currentVersions.size !== 1) {
 
 if (errors.length === 0) {
   for (const row of rows) {
-    if (compareSemver(row.currentVersion, row.baseVersion) <= 0) {
-      errors.push(`${row.label} version must be greater than main (${row.baseVersion}).`);
+    if (semver.order(row.currentVersion as string, row.baseVersion as string) <= 0) {
+      errors.push(`${row.label} version must be greater than main (${formatVersion(row.baseVersion)}).`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a dependency-free Node script that checks Expo plugin version bumps against origin/main
- require Claude, Codex, and Cursor plugin manifests to stay in sync and increase when versioned plugin files change
- add a GitHub Actions workflow that runs on pull_request and merge_group, writes a summary, and posts a sticky PR comment when possible

## Validation
- node --check scripts/check-plugin-version-bump.mjs
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/plugin-version-bump.yml')"\n- node scripts/check-plugin-version-bump.mjs origin/main\n- simulated missing manifest, false-positive path, valid bump, and prerelease bump cases in disposable worktrees