### PR TITLE
merge expo-ui skills

### DIFF
--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/README.md
+++ b/plugins/expo/README.md
@@ -70,8 +70,7 @@ Official AI agent skills from the Expo team for building, deploying, upgrading, 
 - **expo-brownfield** — Integrate Expo and React Native into existing native iOS or Android apps
 - **expo-dev-client** — Build and distribute Expo development clients locally or via TestFlight
 - **expo-tailwind-setup** — Set up Tailwind CSS v4 in Expo with NativeWind v5
-- **expo-ui-jetpack-compose** — Jetpack Compose UI components for Expo
-- **expo-ui-swift-ui** — SwiftUI components for Expo
+- **expo-ui** — Native UI with @expo/ui: universal cross-platform components first, with SwiftUI and Jetpack Compose for platform-specific needs
 - **native-data-fetching** — Network requests, API calls, caching, and offline support
 - **use-dom** — Run web code in a webview on native using DOM components
 

--- a/plugins/expo/skills/expo-ui-jetpack-compose/agents/openai.yaml
+++ b/plugins/expo/skills/expo-ui-jetpack-compose/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Expo UI Jetpack Compose"
-  short_description: "Use @expo/ui/jetpack-compose views and modifiers inside Expo React Native apps"
-  default_prompt: "Use $expo-ui-jetpack-compose when adding or reviewing @expo/ui/jetpack-compose Host trees, Compose-like components, modifiers, Material-style UI, and Android vector icon assets."

--- a/plugins/expo/skills/expo-ui-swift-ui/agents/openai.yaml
+++ b/plugins/expo/skills/expo-ui-swift-ui/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Expo UI SwiftUI"
-  short_description: "Use @expo/ui/swift-ui views and modifiers inside Expo React Native apps"
-  default_prompt: "Use $expo-ui-swift-ui when adding or reviewing @expo/ui/swift-ui Host trees, SwiftUI-like components, modifiers, RNHostView usage, and local Expo-module extensions for missing SwiftUI capabilities."

--- a/plugins/expo/skills/expo-ui/SKILL.md
+++ b/plugins/expo/skills/expo-ui/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: expo-ui
+description: "Build native UI with the @expo/ui package: real SwiftUI on iOS and Jetpack Compose on Android rendered from React in an Expo or React Native app. Covers universal cross-platform components (Host, Column, Row, Button, Text, List, and more imported from @expo/ui), drop-in replacements for popular React Native community libraries (BottomSheet, DateTimePicker, Slider, Menu, etc.), and platform-specific SwiftUI (@expo/ui/swift-ui) and Jetpack Compose (@expo/ui/jetpack-compose) trees and modifiers. Use when adding or reviewing @expo/ui Host/RNHostView trees, building native-feeling UI where standard React Native components fall short (lists with swipe actions and sections, settings forms with toggles, menus, sheets, pickers, sliders), choosing between universal and platform-specific components, or replacing an RN community UI library with a native @expo/ui equivalent. Not for custom native modules, Expo Router navigation, Reanimated, or data fetching."
+version: 1.0.0
+license: MIT
+---
+
+# Expo UI (`@expo/ui`)
+
+`@expo/ui` renders real native UI from React: SwiftUI on iOS, Jetpack Compose on Android. It offers three layers — pick the highest one that satisfies the requirement.
+
+> These instructions track the latest Expo SDK. The **universal** layer requires **SDK 56+**. Drop-in replacements and the platform-specific layers also exist on SDK 55. For component details on a specific SDK, refer to the Expo UI docs for that version.
+
+## Installation
+
+```bash
+npx expo install @expo/ui
+```
+
+A native rebuild is required after installation (`npx expo run:ios` / `npx expo run:android`). Drop-in replacements list Expo Go support in the docs — check the component's doc page before assuming a custom build is required.
+
+Every `@expo/ui` tree — universal or platform-specific — must be wrapped in `Host`.
+
+## Choosing an approach (read this first)
+
+Work down this list and stop at the first layer that meets the need:
+
+1. **Universal components — start here.** Import from the `@expo/ui` root. One component tree runs unmodified on iOS, Android, and web from a single source (Compose on Android, SwiftUI on iOS, `react-native-web`/`react-dom` on web). No platform file splits. → `./references/universal.md`
+
+2. **Drop-in replacements.** API-compatible swaps for popular React Native community libraries (`@gorhom/bottom-sheet`, `@react-native-community/datetimepicker`, `@react-native-community/slider`, and more), backed by native `@expo/ui` components. Import each from `@expo/ui/community/<name>` (e.g. `@expo/ui/community/bottom-sheet`). Reach for these when migrating an existing app off a community UI dependency. → `./references/drop-in-replacements.md`
+
+3. **Platform-specific (SwiftUI / Jetpack Compose).** Import from `@expo/ui/swift-ui` or `@expo/ui/jetpack-compose`. Use **only** when the universal layer is missing a component or modifier you need, or when you need platform-specific behavior or optimization. **Downside:** you write two trees and split them into `.ios.tsx` / `.android.tsx` files (or branch on `Platform.OS`) — more code to maintain. → `./references/swift-ui.md` and `./references/jetpack-compose.md`
+
+## References
+
+Consult these resources as needed:
+
+```
+references/
+  universal.md             Universal @expo/ui components and when to use them (SDK 56+)
+  drop-in-replacements.md  API-compatible replacements for RN community UI libraries
+  swift-ui.md              Platform-specific iOS UI: @expo/ui/swift-ui, RNHostView, extending
+  jetpack-compose.md       Platform-specific Android UI: @expo/ui/jetpack-compose, LazyColumn, icons
+```

--- a/plugins/expo/skills/expo-ui/SKILL.md
+++ b/plugins/expo/skills/expo-ui/SKILL.md
@@ -7,7 +7,7 @@ license: MIT
 
 # Expo UI (`@expo/ui`)
 
-`@expo/ui` renders real native UI from React: SwiftUI on iOS, Jetpack Compose on Android. It offers three layers — pick the highest one that satisfies the requirement.
+`@expo/ui` renders real native UI from React: SwiftUI on iOS, Jetpack Compose on Android. Start with its universal components (one tree for iOS, Android, and web) and drop to platform-specific SwiftUI/Jetpack Compose only when the universal layer falls short. It also ships drop-in replacements for migrating off RN community UI libraries.
 
 > These instructions track the latest Expo SDK. The **universal** layer requires **SDK 56+**. Drop-in replacements and the platform-specific layers also exist on SDK 55. For component details on a specific SDK, refer to the Expo UI docs for that version.
 
@@ -17,7 +17,7 @@ license: MIT
 npx expo install @expo/ui
 ```
 
-A native rebuild is required after installation (`npx expo run:ios` / `npx expo run:android`). Drop-in replacements list Expo Go support in the docs — check the component's doc page before assuming a custom build is required.
+On SDK 56, `@expo/ui` works in Expo Go, so `npx expo start` runs it directly — no custom build required. On older SDKs, build a dev client first (`npx expo run:ios` / `npx expo run:android`).
 
 Every `@expo/ui` tree — universal or platform-specific — must be wrapped in `Host`.
 
@@ -27,9 +27,9 @@ Work down this list and stop at the first layer that meets the need:
 
 1. **Universal components — start here.** Import from the `@expo/ui` root. One component tree runs unmodified on iOS, Android, and web from a single source (Compose on Android, SwiftUI on iOS, `react-native-web`/`react-dom` on web). No platform file splits. → `./references/universal.md`
 
-2. **Drop-in replacements.** API-compatible swaps for popular React Native community libraries (`@gorhom/bottom-sheet`, `@react-native-community/datetimepicker`, `@react-native-community/slider`, and more), backed by native `@expo/ui` components. Import each from `@expo/ui/community/<name>` (e.g. `@expo/ui/community/bottom-sheet`). Reach for these when migrating an existing app off a community UI dependency. → `./references/drop-in-replacements.md`
+2. **Platform-specific (SwiftUI / Jetpack Compose).** Import from `@expo/ui/swift-ui` or `@expo/ui/jetpack-compose`. Use **only** when the universal layer is missing a component or modifier you need, or when you need platform-specific behavior or optimization. **Downside:** you write two trees and split them into `.ios.tsx` / `.android.tsx` files (or branch on `Platform.OS`) — more code to maintain. → `./references/swift-ui.md` and `./references/jetpack-compose.md`
 
-3. **Platform-specific (SwiftUI / Jetpack Compose).** Import from `@expo/ui/swift-ui` or `@expo/ui/jetpack-compose`. Use **only** when the universal layer is missing a component or modifier you need, or when you need platform-specific behavior or optimization. **Downside:** you write two trees and split them into `.ios.tsx` / `.android.tsx` files (or branch on `Platform.OS`) — more code to maintain. → `./references/swift-ui.md` and `./references/jetpack-compose.md`
+**Already using an RN community UI library?** `@expo/ui` also ships **drop-in replacements** — API-compatible swaps for popular libraries (`@gorhom/bottom-sheet`, `@react-native-community/datetimepicker`, and more), imported from `@expo/ui/community/<name>`. This is a migration side-path for replacing an existing dependency, not a step in the universal-vs-platform decision above. → `./references/drop-in-replacements.md`
 
 ## References
 
@@ -39,6 +39,6 @@ Consult these resources as needed:
 references/
   universal.md             Universal @expo/ui components and when to use them (SDK 56+)
   drop-in-replacements.md  API-compatible replacements for RN community UI libraries
-  swift-ui.md              Platform-specific iOS UI: @expo/ui/swift-ui, RNHostView, extending
-  jetpack-compose.md       Platform-specific Android UI: @expo/ui/jetpack-compose, LazyColumn, icons
+  swift-ui.md              Platform-specific iOS UI: @expo/ui/swift-ui components and modifiers
+  jetpack-compose.md       Platform-specific Android UI: @expo/ui/jetpack-compose components and modifiers (incl. LazyColumn, icons)
 ```

--- a/plugins/expo/skills/expo-ui/SKILL.md
+++ b/plugins/expo/skills/expo-ui/SKILL.md
@@ -39,6 +39,6 @@ Consult these resources as needed:
 references/
   universal.md             Universal @expo/ui components and when to use them (SDK 56+)
   drop-in-replacements.md  API-compatible replacements for RN community UI libraries
-  swift-ui.md              Platform-specific iOS UI: @expo/ui/swift-ui components and modifiers
-  jetpack-compose.md       Platform-specific Android UI: @expo/ui/jetpack-compose components and modifiers (incl. LazyColumn, icons)
+  swift-ui.md              Platform-specific iOS UI: @expo/ui/swift-ui components, modifiers, RNHostView, useNativeState
+  jetpack-compose.md       Platform-specific Android UI: @expo/ui/jetpack-compose components, modifiers, LazyColumn caveat, icons, useNativeState
 ```

--- a/plugins/expo/skills/expo-ui/agents/openai.yaml
+++ b/plugins/expo/skills/expo-ui/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Expo UI"
+  short_description: "Build native UI with @expo/ui — universal components first, SwiftUI/Jetpack Compose when needed"
+  default_prompt: "Use $expo-ui when adding or reviewing @expo/ui UI: universal cross-platform components (Host, Column, Row, Button, Text, List, ...), drop-in replacements for React Native community libraries, or platform-specific @expo/ui/swift-ui and @expo/ui/jetpack-compose trees and modifiers. Recommend universal components first; use drop-in replacements when migrating off a community UI library; reach for platform-specific layers only when universal is missing something or you need platform optimization (which requires .ios.tsx/.android.tsx splits)."

--- a/plugins/expo/skills/expo-ui/references/drop-in-replacements.md
+++ b/plugins/expo/skills/expo-ui/references/drop-in-replacements.md
@@ -2,12 +2,6 @@
 
 `@expo/ui` ships API-compatible replacements for popular React Native community libraries, powered by native `@expo/ui` components (Jetpack Compose on Android, SwiftUI on iOS). Use these when migrating an existing app off a community UI dependency — the API matches the library being replaced, so the swap is usually just the import path.
 
-## Installation
-
-```bash
-npx expo install @expo/ui
-```
-
 ## Available replacements
 
 Every drop-in lives under `@expo/ui/community/<kebab-case-name>`. Note which are default vs named imports.
@@ -30,4 +24,4 @@ Each component has a dedicated docs page with setup and usage:
 - Overview — https://docs.expo.dev/versions/latest/sdk/ui/drop-in-replacements/index.md
 - Per component — https://docs.expo.dev/versions/latest/sdk/ui/drop-in-replacements/{component}/index.md (slug is the component name lowercased, no hyphens, e.g. `bottomsheet`, `datetimepicker`, `segmentedcontrol`)
 
-Check the component's doc page for platform support (several support Expo Go) and any props that differ from the library being replaced.
+The installed package's TypeScript types (`.d.ts`) are the most reliable source of truth for the exact props on your SDK version (@expo/ui is versioned with the SDK and its API can change between versions). Use the doc page to find platform support and any props that differ from the library being replaced.

--- a/plugins/expo/skills/expo-ui/references/drop-in-replacements.md
+++ b/plugins/expo/skills/expo-ui/references/drop-in-replacements.md
@@ -1,0 +1,33 @@
+# Drop-in replacements for RN community libraries
+
+`@expo/ui` ships API-compatible replacements for popular React Native community libraries, powered by native `@expo/ui` components (Jetpack Compose on Android, SwiftUI on iOS). Use these when migrating an existing app off a community UI dependency — the API matches the library being replaced, so the swap is usually just the import path.
+
+## Installation
+
+```bash
+npx expo install @expo/ui
+```
+
+## Available replacements
+
+Every drop-in lives under `@expo/ui/community/<kebab-case-name>`. Note which are default vs named imports.
+
+| Replaces | Import |
+|----------|--------|
+| `@gorhom/bottom-sheet` | `import BottomSheet, { BottomSheetView } from '@expo/ui/community/bottom-sheet'` |
+| `@react-native-community/datetimepicker` | `import DateTimePicker from '@expo/ui/community/datetime-picker'` |
+| `@react-native-masked-view/masked-view` | `import { MaskedView } from '@expo/ui/community/masked-view'` |
+| `@react-native-menu/menu` | `import { MenuView } from '@expo/ui/community/menu'` |
+| `react-native-pager-view` | `import PagerView from '@expo/ui/community/pager-view'` |
+| `@react-native-picker/picker` | `import { Picker } from '@expo/ui/community/picker'` |
+| `@react-native-segmented-control/segmented-control` | `import SegmentedControl from '@expo/ui/community/segmented-control'` |
+| `@react-native-community/slider` | `import Slider from '@expo/ui/community/slider'` |
+
+## Confirming the API
+
+Each component has a dedicated docs page with setup and usage:
+
+- Overview — https://docs.expo.dev/versions/latest/sdk/ui/drop-in-replacements/index.md
+- Per component — https://docs.expo.dev/versions/latest/sdk/ui/drop-in-replacements/{component}/index.md (slug is the component name lowercased, no hyphens, e.g. `bottomsheet`, `datetimepicker`, `segmentedcontrol`)
+
+Check the component's doc page for platform support (several support Expo Go) and any props that differ from the library being replaced.

--- a/plugins/expo/skills/expo-ui/references/jetpack-compose.md
+++ b/plugins/expo/skills/expo-ui/references/jetpack-compose.md
@@ -6,7 +6,7 @@ Use this layer only when the universal `@expo/ui` components don't cover what yo
 
 - Expo UI's API mirrors Jetpack Compose's API. Use Jetpack Compose and Material Design 3 knowledge to decide which components or modifiers to use. If you need deeper Jetpack Compose or Material 3 guidance (e.g. which component to pick, layout patterns, theming), spawn a subagent to research [Jetpack Compose](https://developer.android.com/develop/ui/compose/components) and [Material Design 3](https://m3.material.io/) best practices.
 - Components are imported from `@expo/ui/jetpack-compose`, modifiers from `@expo/ui/jetpack-compose/modifiers`.
-- **Always read the `.d.ts` type files** to confirm the exact API before using a component or modifier. Run `node -e "console.log(path.dirname(require.resolve('@expo/ui/jetpack-compose')))"` to locate the package, then read the relevant `{ComponentName}/index.d.ts` files. This is the most reliable source of truth.
+- **Always read the `.d.ts` type files** to confirm the exact API before using a component or modifier — read the relevant `{ComponentName}/index.d.ts` from the installed `@expo/ui/jetpack-compose` package in `node_modules`. This is the most reliable source of truth.
 - When about to use a component, fetch its docs to confirm the API — https://docs.expo.dev/versions/latest/sdk/ui/jetpack-compose/{component-name}/index.md
 - When unsure about a modifier's API, refer to the docs — https://docs.expo.dev/versions/latest/sdk/ui/jetpack-compose/modifiers/index.md
 - Every Jetpack Compose tree must be wrapped in `Host`. Use `<Host matchContents>` for intrinsic sizing, or `<Host style={{ flex: 1 }}>` when you need explicit size (e.g. as a parent of `LazyColumn`). Example:
@@ -22,6 +22,9 @@ import { fillMaxWidth, paddingAll } from "@expo/ui/jetpack-compose/modifiers";
   </Column>
 </Host>;
 ```
+
+- `RNHostView` embeds React Native components inside a Jetpack Compose tree (the same concept as in `@expo/ui/swift-ui`) — wrap any RN child in `<RNHostView>`.
+- If a required composable or modifier is missing in Expo UI, it can be extended via a local Expo module. See: https://docs.expo.dev/guides/expo-ui-jetpack-compose/extending/index.md. Confirm with the user before extending.
 
 ## Key Components
 

--- a/plugins/expo/skills/expo-ui/references/jetpack-compose.md
+++ b/plugins/expo/skills/expo-ui/references/jetpack-compose.md
@@ -1,25 +1,14 @@
----
-name: expo-ui-jetpack-compose
-description: "`@expo/ui/jetpack-compose` package lets you use Jetpack Compose Views and modifiers in your app."
----
+# Platform-specific Android UI: `@expo/ui/jetpack-compose`
 
-> The instructions in this skill apply to SDK 55 only. For other SDK versions, refer to the Expo UI Jetpack Compose docs for that version for the most accurate information.
-
-## Installation
-
-```bash
-npx expo install @expo/ui
-```
-
-A native rebuild is required after installation (`npx expo run:android`).
+Use this layer only when the universal `@expo/ui` components don't cover what you need on Android (see `./universal.md` first). This requires a platform-specific tree, typically in an `.android.tsx` file.
 
 ## Instructions
 
 - Expo UI's API mirrors Jetpack Compose's API. Use Jetpack Compose and Material Design 3 knowledge to decide which components or modifiers to use. If you need deeper Jetpack Compose or Material 3 guidance (e.g. which component to pick, layout patterns, theming), spawn a subagent to research [Jetpack Compose](https://developer.android.com/develop/ui/compose/components) and [Material Design 3](https://m3.material.io/) best practices.
 - Components are imported from `@expo/ui/jetpack-compose`, modifiers from `@expo/ui/jetpack-compose/modifiers`.
 - **Always read the `.d.ts` type files** to confirm the exact API before using a component or modifier. Run `node -e "console.log(path.dirname(require.resolve('@expo/ui/jetpack-compose')))"` to locate the package, then read the relevant `{ComponentName}/index.d.ts` files. This is the most reliable source of truth.
-- When about to use a component, fetch its docs to confirm the API - https://docs.expo.dev/versions/v55.0.0/sdk/ui/jetpack-compose/{component-name}/index.md
-- When unsure about a modifier's API, refer to the docs - https://docs.expo.dev/versions/v55.0.0/sdk/ui/jetpack-compose/modifiers/index.md
+- When about to use a component, fetch its docs to confirm the API — https://docs.expo.dev/versions/latest/sdk/ui/jetpack-compose/{component-name}/index.md
+- When unsure about a modifier's API, refer to the docs — https://docs.expo.dev/versions/latest/sdk/ui/jetpack-compose/modifiers/index.md
 - Every Jetpack Compose tree must be wrapped in `Host`. Use `<Host matchContents>` for intrinsic sizing, or `<Host style={{ flex: 1 }}>` when you need explicit size (e.g. as a parent of `LazyColumn`). Example:
 
 ```jsx

--- a/plugins/expo/skills/expo-ui/references/jetpack-compose.md
+++ b/plugins/expo/skills/expo-ui/references/jetpack-compose.md
@@ -28,5 +28,12 @@ import { fillMaxWidth, paddingAll } from "@expo/ui/jetpack-compose/modifiers";
 
 ## Key Components
 
-- **LazyColumn** — Use instead of react-native `ScrollView`/`FlatList` for scrollable lists. Wrap in `<Host style={{ flex: 1 }}>`.
+- **LazyColumn** — Use instead of react-native `ScrollView`/`FlatList` for scrollable lists. Wrap in `<Host style={{ flex: 1 }}>`. Not suitable for large lists — each item is a JSX node processed on the JS thread, which causes noticeable slowdowns at scale.
 - **Icon** — Use `<Icon source={require('./icon.xml')} size={24} />` with Android XML vector drawables. To get icons: go to [Material Symbols](https://fonts.google.com/icons), select an icon, choose the Android platform, and download the XML vector drawable. Save these as `.xml` files in your project's `assets/` directory (e.g. `assets/icons/wifi.xml`). Metro bundles `.xml` assets automatically — no metro config changes needed.
+
+## useNativeState
+
+`useNativeState` creates observable state that updates synchronously on the UI thread via worklets, enabling immediate native state changes without waiting for a React render cycle. Requires `react-native-worklets` — without it updates still go through React and flickering remains. Best for real-time interactions where synchronous updates matter, e.g. a text field that masks or formats input as the user types.
+
+- `ObservableState.value` is readable/writable from worklets; `onChange` fires a worklet listener on state change.
+- Docs — https://docs.expo.dev/versions/latest/sdk/ui/jetpack-compose/usenativestate/index.md

--- a/plugins/expo/skills/expo-ui/references/swift-ui.md
+++ b/plugins/expo/skills/expo-ui/references/swift-ui.md
@@ -6,13 +6,14 @@ Use this layer only when the universal `@expo/ui` components don't cover what yo
 
 - Expo UI's API mirrors SwiftUI's API. Use SwiftUI knowledge to decide which components or modifiers to use.
 - Components are imported from `@expo/ui/swift-ui`, modifiers from `@expo/ui/swift-ui/modifiers`.
+- **The installed package's TypeScript types (`.d.ts`) are the most reliable source of truth** for the exact API on your SDK version (@expo/ui is versioned with the SDK and its API can change between versions) — read the relevant `{Component}/index.d.ts` from the installed `@expo/ui/swift-ui` package in `node_modules`. Use the docs below as the human-readable reference.
 - When about to use a component, fetch its docs to confirm the API — https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/{component-name}/index.md
 - When unsure about a modifier's API, refer to the docs — https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/modifiers/index.md
 - Every SwiftUI tree must be wrapped in `Host`.
 - `RNHostView` is specifically for embedding RN components inside a SwiftUI tree. Example:
 
 ```jsx
-import { Host, VStack, RNHostView } from "@expo-ui/swift-ui";
+import { Host, VStack, RNHostView } from "@expo/ui/swift-ui";
 import { Pressable } from "react-native";
 
 <Host matchContents>

--- a/plugins/expo/skills/expo-ui/references/swift-ui.md
+++ b/plugins/expo/skills/expo-ui/references/swift-ui.md
@@ -1,24 +1,13 @@
----
-name: expo-ui-swift-ui
-description: "`@expo/ui/swift-ui` package lets you use SwiftUI Views and modifiers in your app."
----
+# Platform-specific iOS UI: `@expo/ui/swift-ui`
 
-> The instructions in this skill apply to SDK 55 only. For other SDK versions, refer to the Expo UI SwiftUI docs for that version for the most accurate information.
-
-## Installation
-
-```bash
-npx expo install @expo/ui
-```
-
-A native rebuild is required after installation (`npx expo run:ios`).
+Use this layer only when the universal `@expo/ui` components don't cover what you need on iOS (see `./universal.md` first). This requires a platform-specific tree, typically in an `.ios.tsx` file.
 
 ## Instructions
 
 - Expo UI's API mirrors SwiftUI's API. Use SwiftUI knowledge to decide which components or modifiers to use.
 - Components are imported from `@expo/ui/swift-ui`, modifiers from `@expo/ui/swift-ui/modifiers`.
-- When about to use a component, fetch its docs to confirm the API - https://docs.expo.dev/versions/v55.0.0/sdk/ui/swift-ui/{component-name}/index.md
-- When unsure about a modifier's API, refer to the docs - https://docs.expo.dev/versions/v55.0.0/sdk/ui/swift-ui/modifiers/index.md
+- When about to use a component, fetch its docs to confirm the API — https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/{component-name}/index.md
+- When unsure about a modifier's API, refer to the docs — https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/modifiers/index.md
 - Every SwiftUI tree must be wrapped in `Host`.
 - `RNHostView` is specifically for embedding RN components inside a SwiftUI tree. Example:
 

--- a/plugins/expo/skills/expo-ui/references/swift-ui.md
+++ b/plugins/expo/skills/expo-ui/references/swift-ui.md
@@ -27,3 +27,10 @@ import { Pressable } from "react-native";
 ```
 
 - If a required modifier or View is missing in Expo UI, it can be extended via a local Expo module. See: https://docs.expo.dev/guides/expo-ui-swift-ui/extending/index.md. Confirm with the user before extending.
+
+## useNativeState
+
+`useNativeState` creates observable state that updates synchronously on the UI thread via worklets, enabling immediate native state changes without waiting for a React render cycle. Requires `react-native-worklets` — without it updates still go through React and flickering remains. Best for real-time interactions where synchronous updates matter, e.g. a text field that masks or formats input as the user types.
+
+- `ObservableState.value` is readable/writable from worklets; `onChange` fires a worklet listener on state change.
+- Docs — https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/usenativestate/index.md

--- a/plugins/expo/skills/expo-ui/references/universal.md
+++ b/plugins/expo/skills/expo-ui/references/universal.md
@@ -30,6 +30,37 @@ import { Host, Column, Button, Text } from '@expo/ui';
 | Disclosure & presentation | `BottomSheet`, `Collapsible` |
 | Collections & forms | `List` (with `ListItem`), `FieldGroup` |
 
+> **`List` is not suitable for large lists.** Each `ListItem` is a JSX node processed on the JS thread — for large datasets this causes noticeable slowdowns.
+
+## TextInput and useNativeState
+
+`TextInput` from `@expo/ui` is **not like React Native's TextInput** — its `value` and `selection` props take an `ObservableState` object (from `useNativeState`), not a plain string. This is what enables synchronous, flicker-free updates: when the user types, `onChangeText` runs as a worklet on the UI thread and writes directly to `value` without a React render cycle.
+
+Requires `react-native-worklets`. Without it the worklet directive has no effect and flickering remains.
+
+```tsx
+import { Host, TextInput, useNativeState } from '@expo/ui';
+import { useCallback } from 'react';
+
+export default function MyInput() {
+  const text = useNativeState('');
+
+  const handleChangeText = useCallback((value: string) => {
+    'worklet';
+    // transform synchronously on the UI thread — no React re-render
+    text.value = value === 'Hello' ? 'World' : value;
+  }, [text]);
+
+  return (
+    <Host matchContents>
+      <TextInput value={text} onChangeText={handleChangeText} placeholder="Type here" />
+    </Host>
+  );
+}
+```
+
+Docs — https://docs.expo.dev/versions/latest/sdk/ui/universal/textinput/index.md
+
 ## Confirming the API
 
 `@expo/ui` is versioned with the Expo SDK (e.g. `56.0.x` for SDK 56) and its API can change between SDK versions, so the **installed package's TypeScript types (`.d.ts`) are the most reliable source of truth** — they match the version in your project, while the docs track latest. Read the relevant component's `.d.ts` from the installed `@expo/ui` package in `node_modules`. Use the docs as the human-readable reference:

--- a/plugins/expo/skills/expo-ui/references/universal.md
+++ b/plugins/expo/skills/expo-ui/references/universal.md
@@ -1,0 +1,48 @@
+# Universal `@expo/ui` components
+
+> Requires Expo SDK 56+.
+
+Universal components are a single-API layer over the platform-native UI toolkits: Jetpack Compose on Android, SwiftUI on iOS, and `react-native-web` / `react-dom` on web. You write one component tree that runs unmodified on all three platforms while keeping a native look and feel — no `.ios.tsx` / `.android.tsx` split.
+
+## Installation
+
+```bash
+npx expo install @expo/ui
+```
+
+## Usage
+
+Import everything, including `Host`, from the package root (`@expo/ui`). Every tree must be wrapped in `Host`.
+
+```tsx
+import { Host, Column, Button, Text } from '@expo/ui';
+
+<Host matchContents>
+  <Column>
+    <Text>Hello</Text>
+    <Button onPress={() => alert('Pressed!')}>Press me</Button>
+  </Column>
+</Host>;
+```
+
+## Components
+
+| Category | Components |
+|----------|------------|
+| Container | `Host` (required root wrapper) |
+| Layout | `Column`, `Row`, `Spacer`, `ScrollView` |
+| Display | `Text`, `Icon` |
+| Controls | `Button`, `Switch`, `Checkbox`, `Slider`, `TextInput`, `Picker` |
+| Disclosure & presentation | `BottomSheet`, `Collapsible` |
+| Collections & forms | `List` (with `ListItem`), `FieldGroup` |
+
+## Confirming the API
+
+Before using a component, fetch its docs to confirm props:
+
+- Overview — https://docs.expo.dev/versions/latest/sdk/ui/universal/index.md
+- Per component — https://docs.expo.dev/versions/latest/sdk/ui/universal/{component-name}/index.md
+
+## When to drop down to a platform-specific layer
+
+Choose universal components whenever they cover the requirement. Drop down to `@expo/ui/swift-ui` or `@expo/ui/jetpack-compose` only when the universal API doesn't expose the component, modifier, or platform-specific behavior you need — accepting the per-platform file split that requires. See `./swift-ui.md` and `./jetpack-compose.md`.

--- a/plugins/expo/skills/expo-ui/references/universal.md
+++ b/plugins/expo/skills/expo-ui/references/universal.md
@@ -4,12 +4,6 @@
 
 Universal components are a single-API layer over the platform-native UI toolkits: Jetpack Compose on Android, SwiftUI on iOS, and `react-native-web` / `react-dom` on web. You write one component tree that runs unmodified on all three platforms while keeping a native look and feel — no `.ios.tsx` / `.android.tsx` split.
 
-## Installation
-
-```bash
-npx expo install @expo/ui
-```
-
 ## Usage
 
 Import everything, including `Host`, from the package root (`@expo/ui`). Every tree must be wrapped in `Host`.
@@ -38,7 +32,7 @@ import { Host, Column, Button, Text } from '@expo/ui';
 
 ## Confirming the API
 
-Before using a component, fetch its docs to confirm props:
+`@expo/ui` is versioned with the Expo SDK (e.g. `56.0.x` for SDK 56) and its API can change between SDK versions, so the **installed package's TypeScript types (`.d.ts`) are the most reliable source of truth** — they match the version in your project, while the docs track latest. Read the relevant component's `.d.ts` from the installed `@expo/ui` package in `node_modules`. Use the docs as the human-readable reference:
 
 - Overview — https://docs.expo.dev/versions/latest/sdk/ui/universal/index.md
 - Per component — https://docs.expo.dev/versions/latest/sdk/ui/universal/{component-name}/index.md


### PR DESCRIPTION
# Why

close ENG-21677

# How

- merge expo-ui skills into one, the `expo-ui` skill
- put universal, drop-in-replacements, swift-ui, and jetpack-compose under references
- recommend to use universal first

# Test Plan

<details>

<summary>evaluate by skill-creator</summary>

# `expo-ui` skill — evaluation summary

**Date:** 2026-06-11 · **Model:** claude-opus-4-8 · **Method:** skill-creator (with-skill vs. no-skill baseline)

## TL;DR

- **The skill works:** with-skill **100%** vs. no-skill baseline **61.3%** pass rate across 4 behavioral test cases.
- **Triggering is already precise** (never fires on near-misses); the description was given a light, readable polish.

---

## 1. Behavioral evals — does the skill change what the agent does?

4 test cases, each run **with the skill** vs. a **no-skill baseline** (1 run per cell).

| Test case | What it checks | With skill | Baseline |
|-----------|----------------|:---------:|:--------:|
| **universal-settings-screen** | Toggles + slider + button, iOS/Android/web → universal-first | **5/5** | 2/5 |
| **dropin-migration** | Swap `@gorhom/bottom-sheet` + datetimepicker for native | **4/4** | 1/4 |
| **platform-specific-swiftui** | Native iOS list (swipe/sections) → drop to `swift-ui` | **4/4** | 4/4 |
| **integrate-swiftui-compose** | "Where do I start with SwiftUI/Compose in Expo?" | **5/5** | 4/5 |
| **Overall (mean pass rate)** | | **100%** | **61.3%** |

### The actual test prompts

1. **universal-settings-screen** — *"I'm building a settings screen in my Expo app. I need a few toggle rows (notifications, dark mode), a volume slider, and a Save button at the bottom. It has to run on iOS, Android, and web. Build it with @expo/ui."*
2. **dropin-migration** — *"Our app uses @gorhom/bottom-sheet and @react-native-community/datetimepicker. I'd like to drop our community dependencies and use native Expo equivalents instead. What's the path?"*
3. **platform-specific-swiftui** — *"On iOS I want a really native-feeling list — SwiftUI swipe actions, section headers, and a specific list style that the cross-platform components don't expose. How should I build this with @expo/ui?"*
4. **integrate-swiftui-compose** — *"I've got an Expo / React Native app and I want to start using SwiftUI on iOS and Jetpack Compose on Android for some of my screens. How do I integrate native SwiftUI / Compose UI into my app — where should I start?"*

## 2. Where the skill moved the needle (and where it didn't)

- **Biggest win — drop-in migration (25% → 100%):** baseline didn't know the drop-in layer exists, pointed at platform-specific components, and called the migration a *"behavioral rewrite, NOT a drop-in."* The skill produced the correct `@expo/ui/community/*` swaps.
- **Universal screen (40% → 100%):** baseline split into `.ios/.android/.web` files and **wrongly claimed `@expo/ui` has no web backend**; the skill produced one universal root tree.
- **Integrate (80% → 100%):** baseline missed universal-first and over-emphasized hand-writing native modules.
- **Tie — platform-specific SwiftUI (100% = 100%):** baseline already handles this path well. Non-discriminating; kept as a no-regression guard.

**Which assertions actually discriminate:** universal-root-import, single-tree (no split), drop-in path/framing, and universal-first ordering.
**Non-discriminating** (pass in both arms): install-step, `Host`-wrap, and the platform-specific import/modifier checks.

## 3. Triggering evals (description optimization)

19 queries (10 should-trigger, 9 should-not), split 12 train / 7 held-out, 3 runs each, 5 iterations.

**Should-trigger examples:**
- *"can i render jetpack compose components from my react native / expo app? wanna use Material 3 stuff"*
- *"how do I swap @react-native-community/datetimepicker for the native expo equivalent"*
- *"what's the Host component in @expo/ui for, and when do I actually need RNHostView?"*

**Should-NOT-trigger examples (tricky near-misses):**
- *"Help me set up bottom tabs + a stack navigator in Expo Router with nice large native headers and a search bar."* → `building-native-ui`
- *"I want to wrap a Swift MapKit view as a native module so I can use it from React Native via the Expo Modules API."* → `expo-module`
- *"I have an existing Kotlin Android app and I want to embed a React Native screen into it."* → `expo-brownfield`
- *"style my profile screen with tailwind / nativewind classes instead of StyleSheet"* → `expo-tailwind-setup`

| Description | Held-out test | Precision | Recall |
|-------------|:-------------:|:---------:|:------:|
| Original | 3/7 | 100% | ~8% |
| Best (iteration 3) | 4/7 | 100% | ~8% |

**Read:** the +1 is **noise**. Precision was already perfect (never fired on a single near-miss — Expo Router, brownfield, native modules, NativeWind, etc.), and the limiter was **under-triggering** on short Q-style queries — a model behavior, not a wording problem. Outcome: kept a readable hybrid description that adds native-feel triggers + explicit `Not for…` boundaries.

</details>