### PR TITLE
Dedupe EAS Workflow syntax out of the expo-deployment skill

### DIFF
--- a/plugins/expo/skills/expo-deployment/SKILL.md
+++ b/plugins/expo/skills/expo-deployment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: expo-deployment
-description: Deploying Expo apps to iOS App Store, Android Play Store, web hosting, and API routes
+description: Deploy Expo apps to production with EAS — build and submit to the iOS App Store, Google Play Store, and TestFlight, configure eas.json build and submit profiles, manage app versions and build numbers, publish App Store metadata and ASO, and deploy web bundles and API routes via EAS Hosting. Use whenever the user is preparing a production build, running eas build or eas submit, shipping to TestFlight, releasing or rolling out to the app stores, bumping version or build numbers, or setting up store listing metadata for an Expo app.
 version: 1.0.0
 license: MIT
 ---
@@ -77,6 +77,8 @@ npx eas-cli@latest deploy --prod
 npx eas-cli@latest deploy
 ```
 
+Expo Router API routes deploy together with the web bundle on EAS Hosting — `eas deploy` ships both. To author or configure the API routes themselves, use the `expo-api-routes` skill.
+
 ## EAS Configuration
 
 Standard `eas.json` for production deployments:
@@ -120,49 +122,24 @@ Standard `eas.json` for production deployments:
 
 - Use `npx testflight` for quick TestFlight submissions
 - Configure Apple credentials via `eas credentials`
-- See ./reference/testflight.md for credential setup
-- See ./reference/ios-app-store.md for App Store submission
+- See ./references/testflight.md for credential setup
+- See ./references/ios-app-store.md for App Store submission
 
 ### Android
 
 - Set up Google Play Console service account
 - Configure tracks: internal → closed → open → production
-- See ./reference/play-store.md for detailed setup
+- See ./references/play-store.md for detailed setup
 
 ### Web
 
 - EAS Hosting provides preview URLs for PRs
 - Production deploys to your custom domain
-- See ./reference/workflows.md for CI/CD automation
+- See ./references/workflows.md for CI/CD automation
 
 ## Automated Deployments
 
-Use EAS Workflows for CI/CD:
-
-```yaml
-# .eas/workflows/release.yml
-name: Release
-
-on:
-  push:
-    branches: [main]
-
-jobs:
-  build-ios:
-    type: build
-    params:
-      platform: ios
-      profile: production
-
-  submit-ios:
-    type: submit
-    needs: [build-ios]
-    params:
-      platform: ios
-      profile: production
-```
-
-See ./reference/workflows.md for more workflow examples.
+EAS Workflows automate the build → submit → update → deploy pipeline for CI/CD. See ./references/workflows.md for deployment-oriented examples. To author or validate workflow YAML, use the `expo-cicd-workflows` skill — it works from the live workflow schema.
 
 ## Version Management
 

--- a/plugins/expo/skills/expo-deployment/references/app-store-metadata.md
+++ b/plugins/expo/skills/expo-deployment/references/app-store-metadata.md
@@ -2,6 +2,24 @@
 
 Manage App Store metadata and optimize for ASO using EAS Metadata.
 
+## Contents
+
+- [What is EAS Metadata?](#what-is-eas-metadata)
+- [Getting Started](#getting-started)
+- [Configuration File](#configuration-file)
+- [App Store Optimization (ASO)](#app-store-optimization-aso)
+- [Categories](#categories)
+- [Localization](#localization)
+- [Dynamic Configuration](#dynamic-configuration)
+- [Age Rating (Advisory)](#age-rating-advisory)
+- [Release Strategy](#release-strategy)
+- [Review Information](#review-information)
+- [ASO Checklist](#aso-checklist)
+- [VS Code Integration](#vs-code-integration)
+- [Common Issues](#common-issues)
+- [CI/CD Integration](#cicd-integration)
+- [Tips](#tips)
+
 ## What is EAS Metadata?
 
 EAS Metadata automates App Store presence management from the command line using a `store.config.json` file instead of manually filling forms in App Store Connect. It includes built-in validation to catch common rejection pitfalls.

--- a/plugins/expo/skills/expo-deployment/references/ios-app-store.md
+++ b/plugins/expo/skills/expo-deployment/references/ios-app-store.md
@@ -1,5 +1,21 @@
 # Submitting to iOS App Store
 
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Credential Setup](#credential-setup)
+- [Submission Commands](#submission-commands)
+- [App Store Connect Configuration](#app-store-connect-configuration)
+- [TestFlight vs App Store](#testflight-vs-app-store)
+- [App Review Process](#app-review-process)
+- [Version and Build Numbers](#version-and-build-numbers)
+- [Release Options](#release-options)
+- [Certificates and Provisioning](#certificates-and-provisioning)
+- [App Store Metadata](#app-store-metadata)
+- [Troubleshooting](#troubleshooting)
+- [CI/CD Integration](#cicd-integration)
+- [Tips](#tips)
+
 ## Prerequisites
 
 1. **Apple Developer Account** - Enroll at [developer.apple.com](https://developer.apple.com)

--- a/plugins/expo/skills/expo-deployment/references/workflows.md
+++ b/plugins/expo/skills/expo-deployment/references/workflows.md
@@ -1,6 +1,8 @@
 # EAS Workflows
 
-Automate builds, submissions, and deployments with EAS Workflows.
+Automate builds, submissions, and deployments with EAS Workflows. The examples below are deployment-oriented starting points.
+
+When you need to write, edit, or validate a workflow YAML file beyond these examples, use the `expo-cicd-workflows` skill.
 
 ## Web Deployment
 
@@ -148,48 +150,6 @@ jobs:
     params:
       platform: all
       profile: production
-```
-
-## Workflow Syntax Reference
-
-### Triggers
-
-```yaml
-on:
-  push:
-    branches: [main, develop]
-    tags: ['v*']
-  pull_request:
-    types: [opened, synchronize, reopened]
-  schedule:
-    - cron: '0 0 * * *'  # Daily at midnight
-  workflow_dispatch:  # Manual trigger
-```
-
-### Job Types
-
-| Type | Purpose |
-|------|---------|
-| `build` | Create app builds |
-| `submit` | Submit to app stores |
-| `update` | Publish OTA updates |
-| `deploy` | Deploy web apps |
-| `run` | Execute custom commands |
-
-### Job Dependencies
-
-```yaml
-jobs:
-  first:
-    type: build
-    params:
-      platform: ios
-
-  second:
-    type: submit
-    needs: [first]  # Runs after 'first' completes
-    params:
-      platform: ios
 ```
 
 ## Tips


### PR DESCRIPTION
# Why

close ENG-21677

# How

- dedupe workflow syntax from expo-deployment skill and recommend to use expo-cicd-workflows skill
- fine tune skill description
- add TOC for ios-app-store.md and app-store-metadata.md because they are large markdowns