### PR TITLE
Center README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 
-<h1 align="center">Expo Skills</h1>
+<h3 align="center">Expo Skills</h3>
 
 <p align="center">
   <a href="https://skills.sh/expo/skills"><img src="https://skills.sh/b/expo/skills" alt="skills.sh installs" /></a>

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-<div align="center">
+<p align="center">
   <a href="https://docs.expo.dev/skills/" target="_blank">
     <img src="assets/expo-skills.png" alt="Expo Skills" width="760" />
   </a>
+</p>
 
-  <h1>Expo Skills</h1>
+<h1 align="center">Expo Skills</h1>
 
-  <p>
-    Official AI agent skills from the Expo team for building, deploying, upgrading, and debugging Expo apps.
-  </p>
+<p align="center">
+  Official AI agent skills from the Expo team for building, deploying, upgrading, and debugging Expo apps.
+</p>
 
-  <p>
-    <a href="https://skills.sh/expo/skills"><img src="https://skills.sh/b/expo/skills" alt="skills.sh installs" /></a>
-    <img src="https://img.shields.io/badge/Expo-official-000020" alt="Official Expo" />
-    <img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT license" />
-  </p>
-</div>
+<p align="center">
+  <a href="https://skills.sh/expo/skills"><img src="https://skills.sh/b/expo/skills" alt="skills.sh installs" /></a>
+  <img src="https://img.shields.io/badge/Expo-official-000020" alt="Official Expo" />
+  <img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT license" />
+</p>
 
 Skills give AI agents focused Expo knowledge: when to use Expo APIs, how to structure common workflows, and which Expo, EAS, React Native, iOS, and Android constraints matter. Expo documentation, Expo CLI, and EAS CLI remain the source of truth; these skills help agents apply them correctly.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 
-<h3 align="center">Expo Skills</h3>
+<h1 align="center">Expo Skills</h1>
 
 <p align="center">
   <a href="https://skills.sh/expo/skills"><img src="https://skills.sh/b/expo/skills" alt="skills.sh installs" /></a>

--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
 <p align="center">
   <a href="https://docs.expo.dev/skills/" target="_blank">
-    <img src="assets/expo-skills.png" alt="Expo Skills" width="760" />
+    <img src="assets/expo-skills.png" alt="Expo Skills" width="100%" />
   </a>
 </p>
 
 <h1 align="center">Expo Skills</h1>
 
 <p align="center">
-  Official AI agent skills from the Expo team for building, deploying, upgrading, and debugging Expo apps.
-</p>
-
-<p align="center">
   <a href="https://skills.sh/expo/skills"><img src="https://skills.sh/b/expo/skills" alt="skills.sh installs" /></a>
   <img src="https://img.shields.io/badge/Expo-official-000020" alt="Official Expo" />
   <img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT license" />
 </p>
+
+<p align="center">
+  Official AI agent skills from the Expo team for building, deploying, upgrading, and debugging Expo apps.
+</p>
+
+## How It Works
 
 Skills give AI agents focused Expo knowledge: when to use Expo APIs, how to structure common workflows, and which Expo, EAS, React Native, iOS, and Android constraints matter. Expo documentation, Expo CLI, and EAS CLI remain the source of truth; these skills help agents apply them correctly.
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 <div align="center">
   <a href="https://docs.expo.dev/skills/" target="_blank">
-    <img src="assets/expo-skills.png" alt="Expo Skills" width="100%" />
+    <img src="assets/expo-skills.png" alt="Expo Skills" width="760" />
   </a>
+
+  <h1>Expo Skills</h1>
+
+  <p>
+    Official AI agent skills from the Expo team for building, deploying, upgrading, and debugging Expo apps.
+  </p>
+
+  <p>
+    <a href="https://skills.sh/expo/skills"><img src="https://skills.sh/b/expo/skills" alt="skills.sh installs" /></a>
+    <img src="https://img.shields.io/badge/Expo-official-000020" alt="Official Expo" />
+    <img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT license" />
+  </p>
 </div>
-
-# Expo Skills
-
-Official AI agent skills from the Expo team for building, deploying, upgrading, and debugging Expo apps.
-
-<p>
-  <a href="https://skills.sh/expo/skills"><img src="https://skills.sh/b/expo/skills" alt="skills.sh installs" /></a>
-  <img src="https://img.shields.io/badge/Expo-official-000020" alt="Official Expo" />
-  <img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT license" />
-</p>
 
 Skills give AI agents focused Expo knowledge: when to use Expo APIs, how to structure common workflows, and which Expo, EAS, React Native, iOS, and Android constraints matter. Expo documentation, Expo CLI, and EAS CLI remain the source of truth; these skills help agents apply them correctly.
 


### PR DESCRIPTION
## Summary
- center the README opening block
- render the banner at a fixed readable width instead of full width
- keep the title, tagline, and badges grouped like a compact repo header

## Testing
- git diff --check
- python3 -m json.tool skills.sh.json >/dev/null