### PR TITLE
Add expo-examples skill

### DIFF
--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/skills/expo-examples/SKILL.md
+++ b/plugins/expo/skills/expo-examples/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: expo-examples
+description: Find, inspect, and scaffold from Expo's official example projects — the expo/examples repo of ~70 `with-*` integrations (Stripe, Clerk, Supabase, OpenAI, maps, Reanimated, SQLite, Skia, React Navigation, Tailwind/NativeWind, and more) — to ground new work in proven, version-matched patterns. Use when integrating a third-party library or service into an Expo app, when the user wants a reference implementation, starting point, or inspiration for a feature, when they ask "is there an example for X" or "how does Expo do X", or when they want to scaffold a project with `npx create-expo --example`.
+allowed-tools: "Read,Bash(gh api:*),Bash(git clone:*),Bash(npx create-expo:*),Bash(npx degit:*),Bash(bun create:*)"
+version: 1.0.0
+license: MIT
+---
+
+# Expo Examples
+
+[expo/examples](https://github.com/expo/examples) is Expo's official library of ~70 **integration examples** — directories named `with-<library>` (e.g. `with-stripe`, `with-maps`), each built around **one** library or service. These are not full apps: they're **managed** projects (no `ios/`/`android/` dirs — native setup is via config plugins), and the typical one is a **single screen of ~100–200 lines**. Mine them for the canonical integration *pattern* — the dependency set, `app.json` config plugins, and minimal wiring Expo maintains against the current SDK — and adapt that into the user's app. Don't expect to lift an application architecture from them.
+
+Reach for an example before hand-rolling an integration. **At a glance:** ~68 are single-concern `with-*` demos; **8 are full-stack** (include Expo Router `+api` routes): `with-stripe`, `with-clerk`, `with-better-auth`, `with-openai`, `with-router-ai`, `with-graphql`, `with-s3`, `with-satori`; a few are larger showcases (`with-shadcn`, `with-router-tv`, `with-react-navigation`); and `blank` / `stickersmash` are starters, not integrations.
+
+## Two modes
+
+1. **Inspiration / adapt** (most common) — the user already has a project. Find the matching example, read its key files, and apply the *pattern* to their code. Do **not** scaffold a whole new project on top of theirs.
+2. **Scaffold** — greenfield. Start a fresh project directly from the example.
+
+## Workflow
+
+### 1. Find the right example
+
+Map the user's need to an example name (e.g. payments → `with-stripe`, auth → `with-clerk`). `./references/catalog.md` is a categorized snapshot for fast triage — but it drifts, so confirm against the live list:
+
+```bash
+# Live example names:
+gh api repos/expo/examples/contents --jq '.[] | select(.type=="dir" and (.name|startswith(".")|not)) | .name'
+# Aliases (renamed) + deprecated (dead/moved) examples — check before recommending:
+gh api repos/expo/examples/contents/meta.json --jq '.content' | base64 -d
+```
+
+`meta.json` is the source of truth for what's renamed or dead. If the example is in its `deprecated` map, don't recommend it — follow the `message` to the modern alternative. If it's in `aliases`, use the `destination`.
+
+### 2a. Inspiration mode — study without touching the user's project
+
+The common case: the user already has an app and wants to see how Expo does something. Read the example as **reference** and apply the patterns by hand — never scaffold an example on top of their project.
+
+**First, list the whole example in one call.** Integration code is often nested (e.g. Stripe's server routes live in `app/api/`), so a one-level listing misses the important files:
+
+```bash
+gh api 'repos/expo/examples/git/trees/master?recursive=1' \
+  --jq '.tree[].path | select(startswith("with-stripe/"))'
+```
+
+**Then read the high-signal files first:** `README.md` (setup) → `package.json` (deps) → `app.json` (config plugins / permissions) → the integration code the manifest revealed → `.env` (required secrets). Per file:
+
+```bash
+gh api repos/expo/examples/contents/with-stripe/utils/stripe-server.ts --jq '.content' | base64 -d
+# No gh? Raw URL (branch is master):
+curl -s https://raw.githubusercontent.com/expo/examples/master/with-stripe/utils/stripe-server.ts
+```
+
+**To study the whole example locally** — read it freely, then apply by hand — pull just that one example into a **throwaway/gitignored dir, not the user's project**:
+
+```bash
+npx degit expo/examples/with-stripe /tmp/expo-ref/with-stripe   # clean copy, no git history
+# fallback without degit (sparse-checkout, no full ~64 MB clone):
+git clone --depth 1 --filter=blob:none --sparse https://github.com/expo/examples.git /tmp/expo-ref/examples \
+  && (cd /tmp/expo-ref/examples && git sparse-checkout set with-stripe)
+```
+
+Read from there with Grep/Read; delete the scratch dir when done.
+
+### 2b. Scaffold mode — new project from an example
+
+```bash
+npx create-expo --example with-stripe   # short form:  npx create-expo -e with-stripe
+bun create expo --example with-stripe    # with bun
+```
+
+### 3. Adapt into the user's app — non-destructively (critical)
+
+When the user already has an app, **add only what the example introduces; never overwrite their setup.**
+
+- **Version-align — don't copy pinned versions.** Examples track the **latest** SDK, so their `package.json` pins won't match an older project. Add only the *missing* deps with `npx expo install <pkg>` (it resolves SDK-correct versions) instead of copying exact versions.
+- **Merge config, don't replace it.** Add only the `app.json`/`app.config.*` plugins and permissions the example introduces that the user lacks — keep their existing config block intact.
+- **Port the integration code**, adapting imports and paths to the user's structure rather than pasting verbatim.
+- **Recreate env vars** from the example's `.env` shape — it holds placeholders, never working secrets.
+
+## Gotchas
+
+- **Deprecated / aliased examples.** `meta.json` marks some examples deprecated (library unmaintained or feature moved) and some as aliases (renamed). Deprecated ones are removed from the repo tree but still listed there with a `message` pointing to the modern path — always check it (step 1) so you never recommend a dead example.
+- **Default branch is `master`,** not `main` (matters for raw URLs and sparse checkout).
+- **Single-click deploy.** Every example has a launch URL: `https://launch.expo.dev/?github=https://github.com/expo/examples/tree/master/<example>`.
+
+## Related skills
+
+- Tailwind / NativeWind styling → `expo-tailwind-setup`
+- Native UI components → `building-native-ui`
+- Authoring a native module → `expo-module`
+- Upgrade the SDK before adopting a latest-SDK example → `upgrading-expo`
+
+## References
+
+- `./references/catalog.md` — categorized snapshot of the example library for fast triage.

--- a/plugins/expo/skills/expo-examples/SKILL.md
+++ b/plugins/expo/skills/expo-examples/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: expo-examples
-description: Find, inspect, and scaffold from Expo's official example projects — the expo/examples repo of ~70 `with-*` integrations (Stripe, Clerk, Supabase, OpenAI, maps, Reanimated, SQLite, Skia, React Navigation, Tailwind/NativeWind, and more) — to ground new work in proven, version-matched patterns. Use when integrating a third-party library or service into an Expo app, when the user wants a reference implementation, starting point, or inspiration for a feature, when they ask "is there an example for X" or "how does Expo do X", or when they want to scaffold a project with `npx create-expo --example`.
+description: Expo's official example projects — the expo/examples repo of ~70 `with-*` integrations (Stripe, Clerk, Supabase, OpenAI, maps, Reanimated, SQLite, Skia, NativeWind, and more). Use when integrating a third-party library or service into an existing Expo app and you want the canonical, version-matched pattern to adapt, or when scaffolding a new project from one with `npx create-expo --example`.
 allowed-tools: "Read,Bash(gh api:*),Bash(git clone:*),Bash(npx create-expo:*),Bash(npx degit:*),Bash(bun create:*)"
 version: 1.0.0
 license: MIT
@@ -10,11 +10,11 @@ license: MIT
 
 [expo/examples](https://github.com/expo/examples) is Expo's official library of ~70 **integration examples** — directories named `with-<library>` (e.g. `with-stripe`, `with-maps`), each built around **one** library or service. These are not full apps: they're **managed** projects (no `ios/`/`android/` dirs — native setup is via config plugins), and the typical one is a **single screen of ~100–200 lines**. Mine them for the canonical integration *pattern* — the dependency set, `app.json` config plugins, and minimal wiring Expo maintains against the current SDK — and adapt that into the user's app. Don't expect to lift an application architecture from them.
 
-Reach for an example before hand-rolling an integration. **At a glance:** ~68 are single-concern `with-*` demos; **8 are full-stack** (include Expo Router `+api` routes): `with-stripe`, `with-clerk`, `with-better-auth`, `with-openai`, `with-router-ai`, `with-graphql`, `with-s3`, `with-satori`; a few are larger showcases (`with-shadcn`, `with-router-tv`, `with-react-navigation`); and `blank` / `stickersmash` are starters, not integrations.
+Reach for an example before hand-rolling an integration. (Kinds — full-stack, showcases, starters — are noted in `./references/catalog.md`.)
 
 ## Two modes
 
-1. **Inspiration / adapt** (most common) — the user already has a project. Find the matching example, read its key files, and apply the *pattern* to their code. Do **not** scaffold a whole new project on top of theirs.
+1. **Inspiration / adapt** (most common) — the user already has a project. Find the matching example, read its key files, and apply the *pattern* to their code.
 2. **Scaffold** — greenfield. Start a fresh project directly from the example.
 
 ## Workflow
@@ -30,7 +30,7 @@ gh api repos/expo/examples/contents --jq '.[] | select(.type=="dir" and (.name|s
 gh api repos/expo/examples/contents/meta.json --jq '.content' | base64 -d
 ```
 
-`meta.json` is the source of truth for what's renamed or dead. If the example is in its `deprecated` map, don't recommend it — follow the `message` to the modern alternative. If it's in `aliases`, use the `destination`.
+`meta.json` is the source of truth for what's renamed or dead (deprecated examples are removed from the repo tree but still listed here, each with a `message`). If an example is in its `deprecated` map, don't recommend it — follow the `message` to the modern path. If it's in `aliases`, use the `destination`.
 
 ### 2a. Inspiration mode — study without touching the user's project
 
@@ -75,12 +75,13 @@ When the user already has an app, **add only what the example introduces; never 
 
 - **Version-align — don't copy pinned versions.** Examples track the **latest** SDK, so their `package.json` pins won't match an older project. Add only the *missing* deps with `npx expo install <pkg>` (it resolves SDK-correct versions) instead of copying exact versions.
 - **Merge config, don't replace it.** Add only the `app.json`/`app.config.*` plugins and permissions the example introduces that the user lacks — keep their existing config block intact.
-- **Port the integration code**, adapting imports and paths to the user's structure rather than pasting verbatim.
+- **Port the integration code.**
 - **Recreate env vars** from the example's `.env` shape — it holds placeholders, never working secrets.
+
+**Done when** the integration code is ported and every dependency, config plugin, permission, and env var it needs is accounted for in the user's app — not when it merely *looks* wired up.
 
 ## Gotchas
 
-- **Deprecated / aliased examples.** `meta.json` marks some examples deprecated (library unmaintained or feature moved) and some as aliases (renamed). Deprecated ones are removed from the repo tree but still listed there with a `message` pointing to the modern path — always check it (step 1) so you never recommend a dead example.
 - **Default branch is `master`,** not `main` (matters for raw URLs and sparse checkout).
 - **Single-click deploy.** Every example has a launch URL: `https://launch.expo.dev/?github=https://github.com/expo/examples/tree/master/<example>`.
 

--- a/plugins/expo/skills/expo-examples/SKILL.md
+++ b/plugins/expo/skills/expo-examples/SKILL.md
@@ -51,7 +51,7 @@ gh api repos/expo/examples/contents/with-stripe/utils/stripe-server.ts --jq '.co
 curl -s https://raw.githubusercontent.com/expo/examples/master/with-stripe/utils/stripe-server.ts
 ```
 
-**To study the whole example locally** — read it freely, then apply by hand — pull just that one example into a **throwaway/gitignored dir, not the user's project**:
+**Reading more than a couple of files?** Many integrations are spread across server routes, a client provider, and config (Stripe is). Skip the per-file calls — pull the whole example into a **throwaway/gitignored dir (not the user's project)** and read it freely with Grep/Read, then apply by hand:
 
 ```bash
 npx degit expo/examples/with-stripe /tmp/expo-ref/with-stripe   # clean copy, no git history

--- a/plugins/expo/skills/expo-examples/references/catalog.md
+++ b/plugins/expo/skills/expo-examples/references/catalog.md
@@ -4,6 +4,12 @@ A categorized view of [expo/examples](https://github.com/expo/examples) for fast
 
 Use any name with `npx create-expo --example <name>` (scaffold) or inspect it via `gh api repos/expo/examples/contents/<name>/<file>`.
 
+Most are single-screen integrations; a few differ:
+
+- **Full-stack** (include Expo Router `+api` routes — a backend too): `with-stripe`, `with-clerk`, `with-better-auth`, `with-openai`, `with-router-ai`, `with-graphql`, `with-s3`, `with-satori`.
+- **Larger showcases:** `with-shadcn`, `with-router-tv`, `with-router-menus`, `with-react-navigation`, `with-webgpu`.
+- **Starters (not integrations):** `blank`, `stickersmash`.
+
 ## Auth & identity
 - `with-clerk` — Clerk authentication
 - `with-auth0` — Auth0 login

--- a/plugins/expo/skills/expo-examples/references/catalog.md
+++ b/plugins/expo/skills/expo-examples/references/catalog.md
@@ -1,0 +1,99 @@
+# Example catalog (snapshot)
+
+A categorized view of [expo/examples](https://github.com/expo/examples) for fast triage. Each entry is a **single-concern integration demo** (one library/service, managed project, usually one screen) — not a full app. This snapshot drifts — the **live repo is the source of truth**. Confirm the exact name against `gh api repos/expo/examples/contents` and check `meta.json` for aliases/deprecations (see SKILL.md step 1) before recommending or scaffolding.
+
+Use any name with `npx create-expo --example <name>` (scaffold) or inspect it via `gh api repos/expo/examples/contents/<name>/<file>`.
+
+## Auth & identity
+- `with-clerk` — Clerk authentication
+- `with-auth0` — Auth0 login
+- `with-better-auth` — Better Auth
+- `with-magic` — Magic passwordless auth
+- `with-facebook-auth` — Facebook login
+- `with-firebase-saml-login` — Firebase SAML SSO
+
+## Payments
+- `with-stripe` — Stripe payments (native + web)
+
+## Backend, data & storage
+- `with-convex` — Convex realtime backend
+- `with-legend-state-supabase` — Supabase + Legend-State sync
+- `with-firebase-storage-upload` — Firebase Storage uploads
+- `with-aws-storage-upload`, `with-s3` — AWS / S3 file uploads
+- `with-apollo`, `with-graphql` — GraphQL clients
+- `with-formdata-image-upload` — multipart image upload
+
+## Local database & state
+- `with-sqlite` — expo-sqlite
+- `with-libsql` — libSQL / Turso
+- `with-tinybase` — TinyBase local-first store
+- `with-zustand` — Zustand state management
+
+## Navigation & routing
+- `with-router` — Expo Router basics
+- `with-react-navigation` — React Navigation (stacks + tabs)
+- `with-drawer-navigation` — drawer navigator
+- `with-router-menus` — native context menus with Router
+- `with-router-uniwind` — Router + Uniwind styling
+- `with-router-ai` — Router + AI chat UI
+- `with-router-tv` — Router on TV
+- `with-react-router` — React Router (web)
+
+## Styling & UI
+- `with-tailwindcss` — Tailwind / NativeWind (see also `expo-tailwind-setup` skill)
+- `with-styled-components` — styled-components
+- `with-shadcn` — shadcn-style components
+- `with-moti` — Moti animations
+- `with-custom-font` — custom fonts
+- `with-svg` — react-native-svg
+- `with-icons` — icon sets
+- `with-splash-screen` — custom splash screen
+- `with-video-background` — full-screen video background
+
+## Animation & graphics
+- `with-reanimated` — Reanimated
+- `with-skia` — React Native Skia 2D graphics
+- `with-three`, `with-react-three-fiber` — three.js / R3F 3D
+- `with-webgpu` — WebGPU
+- `with-processing` — Processing-style sketches
+- `with-react-flow` — node/flow diagrams
+- `with-victory-native` — charts
+
+## AI & ML
+- `with-openai` — OpenAI API
+- `with-router-ai` — AI chat app with Expo Router
+- `with-google-vision` — Google Cloud Vision
+- `with-tfjs-camera` — TensorFlow.js on the camera
+
+## Media & device
+- `with-camera` — expo-camera
+- `with-maps` — react-native-maps
+- `with-webrtc` — WebRTC
+- `with-pdf` — render / view PDFs
+
+## Web & rendering
+- `with-nextjs` — Next.js + Expo
+- `with-rsc` — React Server Components
+- `with-react-strict-dom` — React Strict DOM
+- `with-react-compiler` — React Compiler
+- `with-html` — render raw HTML
+- `with-satori` — OG image generation with Satori
+- `with-workbox` — service worker / PWA
+- `with-webbrowser-redirect` — expo-web-browser auth redirect
+
+## Platform: TV, widgets
+- `with-tv` — Apple TV / Android TV
+- `with-widgets` — iOS / Android home-screen widgets
+
+## Tooling, testing & monorepo
+- `with-typescript` — TypeScript baseline
+- `with-yarn-workspaces` — Yarn monorepo
+- `with-storybook` — Storybook
+- `with-maestro` — Maestro E2E tests
+- `with-sentry` — Sentry error monitoring
+- `with-socket-io` — Socket.IO realtime
+- `with-github-remote-build-cache-provider` — remote build cache on GitHub
+
+## Starters
+- `blank` — minimal app
+- `stickersmash` — the tutorial app


### PR DESCRIPTION
## Summary

Adds a new **`expo-examples`** skill so agents can leverage the official [`expo/examples`](https://github.com/expo/examples) repo — Expo's library of `with-*` integration demos — as version-matched references. Two modes: **study an example for inspiration** (read-only, non-destructive into an existing app) and **scaffold a new project** via `npx create-expo --example`.

## What's actually in `expo/examples` (verified by cloning + analyzing all 70)

These are **integrations, not apps** — the framing the skill is built around:

| Signal | Finding |
| --- | --- |
| Native code | **0 / 70** ship `ios/`/`android/` (all managed projects) |
| Size | Median **137 LOC**, 2 code files; 43/70 ≤200 LOC |
| Structure | 45/70 are a single root `App.js/tsx`; only 11 use a multi-route `app/` dir |
| Naming | 68/70 are `with-<library>`, each built around one headline dependency |

Nuances the skill calls out: **8 are full-stack** (Expo Router `+api` routes — auth/payments/AI), a few are larger showcases (`with-shadcn`, `with-router-tv`, `with-react-navigation`), and `blank`/`stickersmash` are starters, not integrations.

## Design decisions

- **No helper script.** Discovery is just two `gh` commands (live list + `meta.json` for aliases/deprecations); intent→example matching is left to the model rather than a brittle hardcoded synonym table.
- **Non-destructive adapt.** For an existing app: version-align with `npx expo install`, add only missing config plugins, never overwrite `app.json`.
- **Full-manifest discovery** via the recursive git-tree API, so nested integration code (e.g. Stripe's `app/api/` routes) isn't missed.
- **`meta.json` as source of truth** for renamed (alias) and dead (deprecated) examples.

## Files

- `plugins/expo/skills/expo-examples/SKILL.md`
- `plugins/expo/skills/expo-examples/references/catalog.md` — categorized snapshot
- Bumped Claude/Codex/Cursor plugin manifests `1.2.0 → 1.3.0` (required by the version-bump check)

## Validation

- `claude plugin validate .` and `./plugins/expo` pass
- Plugin version-bump check passes (all three manifests bumped together):

| Plugin | main | PR |
| --- | --- | --- |
| Claude | 1.2.0 | 1.3.0 |
| Codex | 1.2.0 | 1.3.0 |
| Cursor | 1.2.0 | 1.3.0 |

## Future

Name reserved as `expo-examples` (mirrors the repo + `--example`); a future `expo-templates` skill can cover larger UI app starters (`create-expo-app --template`), disambiguated via descriptions + cross-links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)