### PR TITLE
improve building-native-ui skill

### DIFF
--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",
@@ -35,12 +35,7 @@
     "longDescription": "Official Expo-authored skills for building Expo Router UI, authoring API routes, configuring data fetching and styling, writing Expo native modules, adding App Clips, integrating Expo into brownfield native apps, inspecting EAS Update health, creating dev clients, upgrading Expo SDKs, wiring Codex app Run actions, using Expo MCP, and deploying Expo apps with EAS workflows, builds, hosting, TestFlight, App Store, and Play Store guidance.",
     "developerName": "Expo",
     "category": "Developer Tools",
-    "capabilities": [
-      "Interactive",
-      "Read",
-      "Write",
-      "MCP"
-    ],
+    "capabilities": ["Interactive", "Read", "Write", "MCP"],
     "websiteURL": "https://expo.dev/",
     "privacyPolicyURL": "https://expo.dev/privacy",
     "termsOfServiceURL": "https://expo.dev/terms",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/skills/building-native-ui/SKILL.md
+++ b/plugins/expo/skills/building-native-ui/SKILL.md
@@ -88,6 +88,8 @@ See `./references/route-structure.md` for detailed route conventions.
 - `React.use` not `React.useContext`
 - `expo-image` Image component instead of intrinsic element `img`
 - `expo-glass-effect` for liquid glass backdrops
+- `Color` from `expo-router` for native semantic colors, not raw `PlatformColor` (type-safe, auto-adapts to light/dark)
+- In SDK 56+, never import from `@react-navigation/*` directly — use `expo-router/react-navigation` instead (covers `@react-navigation/native`, `/core`, `/elements`, `/routers`)
 
 ## Responsiveness
 
@@ -127,52 +129,55 @@ Follow Apple Human Interface Guidelines.
 
 ## Colors
 
-Apple semantic color names (`label`, `secondaryLabel`, `separator`, `systemBackground`, `systemBlue`, etc.) exist **only on iOS**. Rendering `PlatformColor("label")` on Android crashes with `ColorValue: None of the paths in the resource_paths array resolved`.
+Use the `Color` API from `expo-router` for native semantic colors. It is a type-safe wrapper over `PlatformColor` that exposes iOS UIKit colors through `Color.ios.*` and Android Material 3 colors through `Color.android.material.*` (static) or `Color.android.dynamic.*` (adapts to the user's wallpaper on Android 12+). These resolve on-device and automatically adapt to light/dark mode and accessibility settings, so you no longer maintain separate light/dark hex tables or a `colors.web.ts` file.
 
-Never pass a raw `PlatformColor(...)` with an Apple name to a cross-platform view. Wrap every one in `Platform.select`, mapping the iOS name to its Android theme attribute with a hex fallback. Keep them in one helper and import `colors.*` everywhere:
+`Color` is platform-specific, so wrap each value in `Platform.select` with a `default` hex fallback for web. Centralize the palette in `theme/colors.ts` and import `colors` everywhere:
 
 ```tsx
 // theme/colors.ts
-import { Platform, PlatformColor } from "react-native";
+import { Platform } from "react-native";
+import { Color } from "expo-router";
 
 export const colors = {
   label: Platform.select({
-    ios: PlatformColor("label"),
-    android: PlatformColor("?android:attr/textColorPrimary"),
-    default: "#000",
-  }),
+    ios: Color.ios.label,
+    android: Color.android.dynamic.onSurface,
+    default: "#000000",
+  })!,
   secondaryLabel: Platform.select({
-    ios: PlatformColor("secondaryLabel"),
-    android: PlatformColor("?android:attr/textColorSecondary"),
+    ios: Color.ios.secondaryLabel,
+    android: Color.android.dynamic.onSurfaceVariant,
     default: "#3c3c43",
-  }),
+  })!,
   separator: Platform.select({
-    ios: PlatformColor("separator"),
-    android: "#c6c6c8", // no framework color attr (listDivider is a drawable)
+    ios: Color.ios.separator,
+    android: Color.android.dynamic.outlineVariant,
     default: "#c6c6c8",
-  }),
+  })!,
   systemBackground: Platform.select({
-    ios: PlatformColor("systemBackground"),
-    android: PlatformColor("?android:attr/colorBackground"),
-    default: "#fff",
-  }),
+    ios: Color.ios.systemBackground,
+    android: Color.android.dynamic.surface,
+    default: "#ffffff",
+  })!,
   systemBlue: Platform.select({
-    ios: PlatformColor("systemBlue"),
-    android: PlatformColor("?android:attr/colorAccent"),
+    ios: Color.ios.systemBlue,
+    android: Color.android.dynamic.primary,
     default: "#007aff",
-  }),
+  })!,
 };
 ```
 
-`Platform.select` only resolves the current platform's value, so the iOS-only names never reach Android. Style with `colors.label`, `colors.separator`, etc. — not raw `PlatformColor(...)`.
+```tsx
+import { colors } from "@/theme/colors";
 
-| iOS semantic name | Android theme attribute |
-| --- | --- |
-| `label` | `?android:attr/textColorPrimary` |
-| `secondaryLabel` | `?android:attr/textColorSecondary` |
-| `systemBackground` | `?android:attr/colorBackground` |
-| `systemBlue` | `?android:attr/colorAccent` |
-| `separator` | none — use a hex fallback |
+<View style={{ backgroundColor: colors.systemBackground }}>
+  <Text style={{ color: colors.label }}>Title</Text>
+</View>;
+```
+
+- iOS re-resolves these colors automatically when the system theme changes. On Android, call `useColorScheme()` inside any component that renders them so it re-renders when the theme flips (required when React Compiler memoizes the component).
+- Don't pass `Color` / `PlatformColor` values into Reanimated styles — use static colors there (see `references/animations.md`).
+- `Platform.select({...})!` returns `string | OpaqueColorValue`. Most React Native style props accept `ColorValue` (`string | OpaqueColorValue`) so this works fine. But some third-party props only accept `string` (e.g. `tintColor` on `expo-image`). Cast when needed: `colors.label as string`.
 
 ## Text Styling
 
@@ -320,20 +325,22 @@ app/
 
 ```tsx
 // app/_layout.tsx
-import { NativeTabs, Icon, Label } from "expo-router/unstable-native-tabs";
-import { Theme } from "../components/theme";
+import { NativeTabs } from "expo-router/unstable-native-tabs";
+import { ThemeProvider, DarkTheme, DefaultTheme } from "expo-router/react-navigation";
+import { useColorScheme } from "react-native";
 
 export default function Layout() {
+  const colorScheme = useColorScheme();
   return (
-    <Theme>
+    <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
       <NativeTabs>
         <NativeTabs.Trigger name="(index)">
-          <Icon sf="list.dash" />
-          <Label>Items</Label>
+          <NativeTabs.Trigger.Icon sf="list.dash" md="list" />
+          <NativeTabs.Trigger.Label>Items</NativeTabs.Trigger.Label>
         </NativeTabs.Trigger>
         <NativeTabs.Trigger name="(search)" role="search" />
       </NativeTabs>
-    </Theme>
+    </ThemeProvider>
   );
 }
 ```

--- a/plugins/expo/skills/building-native-ui/SKILL.md
+++ b/plugins/expo/skills/building-native-ui/SKILL.md
@@ -125,6 +125,55 @@ Follow Apple Human Interface Guidelines.
 - When padding a ScrollView, use `contentContainerStyle` padding and gap instead of padding on the ScrollView itself (reduces clipping)
 - CSS and Tailwind are not supported - use inline styles
 
+## Colors
+
+Apple semantic color names (`label`, `secondaryLabel`, `separator`, `systemBackground`, `systemBlue`, etc.) exist **only on iOS**. Rendering `PlatformColor("label")` on Android crashes with `ColorValue: None of the paths in the resource_paths array resolved`.
+
+Never pass a raw `PlatformColor(...)` with an Apple name to a cross-platform view. Wrap every one in `Platform.select`, mapping the iOS name to its Android theme attribute with a hex fallback. Keep them in one helper and import `colors.*` everywhere:
+
+```tsx
+// theme/colors.ts
+import { Platform, PlatformColor } from "react-native";
+
+export const colors = {
+  label: Platform.select({
+    ios: PlatformColor("label"),
+    android: PlatformColor("?android:attr/textColorPrimary"),
+    default: "#000",
+  }),
+  secondaryLabel: Platform.select({
+    ios: PlatformColor("secondaryLabel"),
+    android: PlatformColor("?android:attr/textColorSecondary"),
+    default: "#3c3c43",
+  }),
+  separator: Platform.select({
+    ios: PlatformColor("separator"),
+    android: "#c6c6c8", // no framework color attr (listDivider is a drawable)
+    default: "#c6c6c8",
+  }),
+  systemBackground: Platform.select({
+    ios: PlatformColor("systemBackground"),
+    android: PlatformColor("?android:attr/colorBackground"),
+    default: "#fff",
+  }),
+  systemBlue: Platform.select({
+    ios: PlatformColor("systemBlue"),
+    android: PlatformColor("?android:attr/colorAccent"),
+    default: "#007aff",
+  }),
+};
+```
+
+`Platform.select` only resolves the current platform's value, so the iOS-only names never reach Android. Style with `colors.label`, `colors.separator`, etc. — not raw `PlatformColor(...)`.
+
+| iOS semantic name | Android theme attribute |
+| --- | --- |
+| `label` | `?android:attr/textColorPrimary` |
+| `secondaryLabel` | `?android:attr/textColorSecondary` |
+| `systemBackground` | `?android:attr/colorBackground` |
+| `systemBlue` | `?android:attr/colorAccent` |
+| `separator` | none — use a hex fallback |
+
 ## Text Styling
 
 - Add the `selectable` prop to every `<Text/>` element displaying important data or error messages
@@ -294,7 +343,7 @@ Create a shared group route so both tabs can push common screens:
 ```tsx
 // app/(index,search)/_layout.tsx
 import { Stack } from "expo-router/stack";
-import { PlatformColor } from "react-native";
+import { colors } from "@/theme/colors";
 
 export default function Layout({ segment }) {
   const screen = segment.match(/\((.*)\)/)?.[1]!;
@@ -307,7 +356,7 @@ export default function Layout({ segment }) {
         headerShadowVisible: false,
         headerLargeTitleShadowVisible: false,
         headerLargeStyle: { backgroundColor: "transparent" },
-        headerTitleStyle: { color: PlatformColor("label") },
+        headerTitleStyle: { color: colors.label },
         headerLargeTitle: true,
         headerBlurEffect: "none",
         headerBackButtonDisplayMode: "minimal",

--- a/plugins/expo/skills/building-native-ui/references/animations.md
+++ b/plugins/expo/skills/building-native-ui/references/animations.md
@@ -214,7 +214,7 @@ Animate list items with delays:
 - Use layout animations when items are added/removed from lists
 - Use `useAnimatedStyle` for scroll-driven animations
 - Prefer `interpolate` with "clamp" for bounded values
-- You can't pass PlatformColors to reanimated views or styles; use static colors instead
+- You can't pass `Color` (from expo-router) or `PlatformColor` values to reanimated views or styles; use static colors instead
 - Keep animations under 300ms for responsive feel
 - Use spring animations for natural movement
 - Avoid animating layout properties (width, height) when possible — prefer transforms

--- a/plugins/expo/skills/building-native-ui/references/icons.md
+++ b/plugins/expo/skills/building-native-ui/references/icons.md
@@ -6,10 +6,10 @@ Use SF Symbols for native feel. Never use FontAwesome or Ionicons.
 
 ```tsx
 import { SymbolView } from "expo-symbols";
-import { PlatformColor } from "react-native";
+import { colors } from "@/theme/colors";
 
 <SymbolView
-  tintColor={PlatformColor("label")}
+  tintColor={colors.label}
   resizeMode="scaleAspectFit"
   name="square.and.arrow.down"
   style={{ width: 16, height: 16 }}
@@ -21,7 +21,7 @@ import { PlatformColor } from "react-native";
 ```tsx
 <SymbolView
   name="star.fill"                    // SF Symbol name (required)
-  tintColor={PlatformColor("label")}  // Icon color
+  tintColor={colors.label}            // Icon color
   size={24}                           // Shorthand for width/height
   resizeMode="scaleAspectFit"         // How to scale
   weight="regular"                    // thin | ultraLight | light | regular | medium | semibold | bold | heavy | black
@@ -209,5 +209,5 @@ Some symbols support multiple colors:
 - Always use SF Symbols over vector icon libraries
 - Match symbol weight to nearby text weight
 - Use `.fill` variants for selected/active states
-- Use PlatformColor for tint to support dark mode
+- Use the cross-platform `colors` helper (see SKILL.md "Colors") for tint to support dark mode
 - Keep icons at consistent sizes (16, 20, 24, 32)

--- a/plugins/expo/skills/building-native-ui/references/media.md
+++ b/plugins/expo/skills/building-native-ui/references/media.md
@@ -17,7 +17,7 @@ import * as MediaLibrary from "expo-media-library";
 import * as ImagePicker from "expo-image-picker";
 import * as Haptics from "expo-haptics";
 import { SymbolView } from "expo-symbols";
-import { PlatformColor } from "react-native";
+import { colors } from "@/theme/colors";
 import { GlassView } from "expo-glass-effect";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -29,9 +29,9 @@ function Camera({ onPicture }: { onPicture: (uri: string) => Promise<void> }) {
 
   if (!permission?.granted) {
     return (
-      <View style={{ flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: PlatformColor("systemBackground") }}>
-        <Text style={{ color: PlatformColor("label"), padding: 16 }}>Camera access is required</Text>
-        <GlassView isInteractive tintColor={PlatformColor("systemBlue")} style={{ borderRadius: 12 }}>
+      <View style={{ flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: colors.systemBackground }}>
+        <Text style={{ color: colors.label, padding: 16 }}>Camera access is required</Text>
+        <GlassView isInteractive tintColor={colors.systemBlue} style={{ borderRadius: 12 }}>
           <TouchableOpacity onPress={requestPermission} style={{ padding: 12, borderRadius: 12 }}>
             <Text style={{ color: "white" }}>Grant Permission</Text>
           </TouchableOpacity>

--- a/plugins/expo/skills/building-native-ui/references/search.md
+++ b/plugins/expo/skills/building-native-ui/references/search.md
@@ -208,7 +208,7 @@ function SearchResults({ search, items }) {
   if (search && filtered.length === 0) {
     return (
       <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
-        <Text style={{ color: PlatformColor("secondaryLabel") }}>
+        <Text style={{ color: colors.secondaryLabel }}>
           No results for "{search}"
         </Text>
       </View>
@@ -231,7 +231,7 @@ function SearchScreen() {
   if (!search && recentSearches.length > 0) {
     return (
       <View>
-        <Text style={{ color: PlatformColor("secondaryLabel") }}>
+        <Text style={{ color: colors.secondaryLabel }}>
           Recent Searches
         </Text>
         {recentSearches.map((term) => (

--- a/plugins/expo/skills/building-native-ui/references/visual-effects.md
+++ b/plugins/expo/skills/building-native-ui/references/visual-effects.md
@@ -98,11 +98,11 @@ Add `isInteractive` for buttons and pressable glass:
 ```tsx
 import { GlassView } from "expo-glass-effect";
 import { SymbolView } from "expo-symbols";
-import { PlatformColor } from "react-native";
+import { colors } from "@/theme/colors";
 
 <GlassView isInteractive style={{ borderRadius: 50 }}>
   <Pressable style={{ padding: 12 }} onPress={handlePress}>
-    <SymbolView name="plus" tintColor={PlatformColor("label")} size={36} />
+    <SymbolView name="plus" tintColor={colors.label} size={36} />
   </Pressable>
 </GlassView>
 ```
@@ -116,7 +116,7 @@ function GlassButton({ icon, onPress }) {
   return (
     <GlassView isInteractive style={{ borderRadius: 50 }}>
       <Pressable style={{ padding: 12 }} onPress={onPress}>
-        <SymbolView name={icon} tintColor={PlatformColor("label")} size={24} />
+        <SymbolView name={icon} tintColor={colors.label} size={24} />
       </Pressable>
     </GlassView>
   );
@@ -131,10 +131,10 @@ function GlassButton({ icon, onPress }) {
 
 ```tsx
 <GlassView style={{ borderRadius: 20, padding: 20 }}>
-  <Text style={{ fontSize: 18, fontWeight: '600', color: PlatformColor("label") }}>
+  <Text style={{ fontSize: 18, fontWeight: '600', color: colors.label }}>
     Card Title
   </Text>
-  <Text style={{ color: PlatformColor("secondaryLabel"), marginTop: 8 }}>
+  <Text style={{ color: colors.secondaryLabel, marginTop: 8 }}>
     Card content goes here
   </Text>
 </GlassView>


### PR DESCRIPTION
# Why

feedback/findings from expo-skill-eval

# How

originally we have `PlatformColor` that doesn't work on android. this pr tries to add android PlatformColor support

# Test Plan

using expo-skill-eval without errors