### PR TITLE
[eas-simulator] argent remote install + dogfood gaps

### DIFF
--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/skills/eas-simulator/SKILL.md
+++ b/plugins/expo/skills/eas-simulator/SKILL.md
@@ -3,7 +3,7 @@ name: eas-simulator
 description: "EAS service (paid). Run and control a user's app on a remote iOS/Android simulator hosted on EAS cloud. Read before running any `eas simulator:*` commands - it has the current syntax for this experimental API. Use whenever the user needs a simulator they can't run locally - 'run my app on a cloud simulator', 'use eas simulator to run/install/screenshot my app', 'I'm on Linux/Cursor and need an iOS device', 'no sim on this box / headless CI', 'let an agent click through my app and screenshot it', 'test my dev build on a remote sim with live reload', 'stream a sim to my browser' - even when they don't say 'EAS Simulator' or 'cloud'. On a host WITHOUT a local simulator (Linux, CI, cloud sandbox) it's the default; on macOS, do NOT auto-trigger for a plain 'run on the simulator' - use it only for a cloud/remote/shareable sim, an iOS version they lack, or an agent-driven session. NOT for local sims (expo run:ios, Xcode, Android Studio), EAS Build/Update, web preview, or physical devices."
 version: 1.0.0
 license: MIT
-allowed-tools: "Bash(npx *eas-cli@*), Bash(npx *agent-device@*), Bash(npx expo *), Bash(eas *), Bash(expo *), Bash(xcodebuild*), Bash(pod*)"
+allowed-tools: "Bash(npx *eas-cli@*), Bash(npx *agent-device@*), Bash(npx expo *), Bash(eas *), Bash(expo *), Bash(xcodebuild*), Bash(pod*), Bash(argent *)"
 ---
 
 # EAS Simulator
@@ -41,6 +41,7 @@ fi
 - A controller to drive the device. This skill uses **agent-device** (open source, MIT), run on demand via `npx agent-device@latest` — nothing globally installed. **argent** is an alternative (`--type argent` in `simulator:start`); see [references/controllers.md](./references/controllers.md).
 - **`.env.eas-simulator`** is written/managed by eas-cli (not this skill): it holds the session id (`EAS_SIMULATOR_SESSION_ID`) + the daemon URL/**token**, so `get`/`stop`/`exec` default to that session (usually **omit `--id`**; pass `--id <id>` to target another). It carries a **token → keep it gitignored** (eas-cli marks it "do not commit" but may not add the ignore rule, and a fresh app's `.gitignore` won't cover it — add `.env.eas-simulator` if missing).
 - `--max-duration-minutes` is paid-plan only; otherwise a default applies.
+- **The command blocks assume a POSIX shell** (bash/zsh) — `printf`, `lsof`, `$(seq …)` loops won't run in cmd/PowerShell. On Windows, run them in WSL or Git Bash, or translate as you go (the `eas-cli`/`agent-device` invocations themselves are cross-platform).
 
 ## The core loop (always the same)
 
@@ -76,7 +77,7 @@ To **watch** it live, hand the user the `webPreviewUrl` that `start` prints (an 
 
 | Command | Purpose |
 |---|---|
-| `npx --yes eas-cli@latest simulator:start --platform ios\|android [--type agent-device\|argent\|serve-sim] [--package-version X] [--max-duration-minutes N] [--non-interactive] [--json]` | Create a session; boot the sim + controller; write `.env.eas-simulator`; print `webPreviewUrl` + job-run URL |
+| `npx --yes eas-cli@latest simulator:start --platform ios\|android [--type agent-device\|argent\|serve-sim] [--package-version X] [--max-duration-minutes N] [--non-interactive] [--json]` | Create a session; boot the sim + controller; write `.env.eas-simulator`; print `webPreviewUrl` + job-run URL. **`--json` suppresses the `.env.eas-simulator` write** — omit it for the `exec` flow, or set the env yourself from `remoteConfig`. |
 | `npx --yes eas-cli@latest simulator:exec <cmd> [args…]` | Load `.env.eas-simulator`, then run `<cmd>` with that env. The bridge to the controller. |
 | `npx --yes eas-cli@latest simulator:get [--id] [--json]` | Session status + connection details. **Use this to confirm readiness** (see *Operating principles*). |
 | `npx --yes eas-cli@latest simulator:list [--status …] [--type …] [--platform …]` | List an app's sessions |
@@ -109,7 +110,7 @@ Quick decision — **default to C; A and B are explicit-only:**
 
 | Verb | Does |
 |---|---|
-| `apps --platform ios` | List installed apps (the blank sim shows none) |
+| `apps --platform ios` | List user-installed apps (the blank sim shows none); add `--all` to include system apps |
 | `install <appId> <path> --platform ios` | Install a local `.app` (uploads it) |
 | `install-from-source <url> --platform ios` | Install from a URL — the VM downloads it (use for EAS artifacts) |
 | `open <appId\|deep-link> --platform ios` | Launch an app (bundle id) or follow an app **deep link** (`exp+slug://…`). **Not** for the `webPreviewUrl` — that's a browser preview for the user, never the device. |
@@ -149,7 +150,7 @@ printf '# managed by eas-cli\n' > .env.eas-simulator   # clear the stale session
 
 ## References
 
-- [references/run-your-app.md](./references/run-your-app.md) — full tested command sequences for modes A, B, and C (read before running a mode).
+- [references/run-your-app.md](./references/run-your-app.md) — full command sequences for modes A, B, and C (read before running a mode).
 - [references/controllers.md](./references/controllers.md) — agent-device verb reference and the `argent` alternative.
 - [references/troubleshooting.md](./references/troubleshooting.md) — concrete errors and fixes.
 

--- a/plugins/expo/skills/eas-simulator/references/controllers.md
+++ b/plugins/expo/skills/eas-simulator/references/controllers.md
@@ -22,13 +22,21 @@ EAS-specific notes:
 - **`press`, not `tap`.** The tap verb is `press` — `tap` is not a verb.
 - **`snapshot -i` is slow on iOS** — tens of seconds is normal; wait for it.
 - **`install` uploads** a local binary to the daemon; **`install-from-source`** has the VM download from a URL (use for EAS artifacts — avoids a large upload).
-- **Proven in this skill's flows:** `apps`, `install`, `install-from-source`, `open`, `snapshot -i`, `press`, `fill`, `screenshot`. Others (`gesture`/`scroll`/`logs`/`record`/`network`/`perf`/`metro`) are real in the CLI but not exercised here — confirm via `<verb> --help` before relying on them.
+- **Exercised against a live session:** `apps`, `install`, `install-from-source`, `open`, `snapshot -i`, `press`, `fill`, `screenshot`, `scroll`, `gesture` (needs a preset, e.g. `gesture swipe left`), `logs`, `record` (`start`/`stop <path>`), `network`, `perf`. `metro` (`prepare`/`reload`) is the Mode C dev-client bridge. Pass `--platform ios`; run `<verb>` with no args to see its required subcommand/args.
 
 ## argent (alternative)
 
 `npx --yes eas-cli@latest simulator:start --type argent` provisions an argent remote session. The connection config it returns is different (`ARGENT_TOOLS_URL` / `ARGENT_AUTH_TOKEN`).
 
-**argent sessions cannot install apps today.** `--type argent` provisions only an argent daemon on the VM — there is no agent-device daemon, so agent-device install commands don't apply. Use argent to drive an app that is already on the sim (e.g. start with `--type agent-device` to install, then switch; or use an EAS build with `install-from-source` via an agent-device session first).
+**Installing apps in an argent session.** `--type argent` provisions only an argent daemon on the VM — there is no agent-device daemon, so agent-device install verbs don't apply. Install a local build with argent's own `reinstall-app` (tar-upload):
+
+```bash
+argent run reinstall-app --udid <udid> --bundleId <bundle-id> --appPath ./MyApp.app
+```
+
+Whenever the tools client is routed to a remote tool-server, it tars the local bundle and streams it up automatically — no extra flag. "Remote" covers both `argent link` and the env-var MCP config (`ARGENT_TOOLS_URL`), so this works in sandboxed shells too. It's a registry tool, so the MCP server exposes it identically — same call by CLI or MCP. Works for iOS `.app` (a directory), Android `.apk`, and Vega `.vpkg`; the client prints an upload line on stderr.
+
+Needs argent ≥ 0.16.0 (the release that adds tar-upload) — verify with `argent --version`. On older versions `reinstall-app` resolves `--appPath` on the VM only, so a local path fails; drive an app already on the sim instead.
 
 **Connecting via MCP (Cursor, Claude Code, Codex, and others).** Install the CLI globally first — the package is `@swmansion/argent`, not `argent`:
 
@@ -65,3 +73,4 @@ MCP config file location: `.cursor/mcp.json` (Cursor), `.claude/mcp.json` (Claud
 
 **Known issues:**
 - `argent init --help` launches an interactive wizard regardless of the flag — use `--yes` to skip it, or read the package source for non-interactive flags.
+- Re-running `argent link` against an already-linked URL **without `--yes`** reports "Already linked. No changes." and keeps the old token — every call then fails with `401 Unauthorized`. Always pass `--yes` (as above) so a rotated token is actually written.

--- a/plugins/expo/skills/eas-simulator/references/run-your-app.md
+++ b/plugins/expo/skills/eas-simulator/references/run-your-app.md
@@ -68,7 +68,7 @@ The `install` here **uploads** the (~90MB) `.app` to the remote daemon over the 
 
 ```bash
 npx --yes eas-cli@latest build:list --platform ios --profile <your-sim-profile> --status finished --json | \
-  head -20   # look for a sim build whose fingerprint matches current source
+  head -20   # <your-sim-profile> = the profile you find/create in step 1; look for one whose fingerprint matches current source
 ```
 
 If one matches, skip straight to step 3 with its artifact URL.

--- a/plugins/expo/skills/eas-simulator/references/troubleshooting.md
+++ b/plugins/expo/skills/eas-simulator/references/troubleshooting.md
@@ -4,7 +4,7 @@ Concrete errors seen while validating this flow, and the fix.
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `Command simulator:start not found` | `eas-cli` too old (commands are hidden but present from ≥ 20.3.0) | Run via `npx eas-cli@latest …`, or upgrade `eas-cli`. |
+| `Command simulator:start not found` | `eas-cli` too old (commands are hidden but present from ≥ 20.3.0) | Run via `npx --yes eas-cli@latest …`, or upgrade `eas-cli`. |
 | `An Expo user account is required` / `whoami` shows logged-out | No browser login on a cloud/CI/headless box, or `EXPO_TOKEN` unset/invalid | Set **`EXPO_TOKEN`** (expo.dev → Account → Access Tokens) in the env; verify `npx --yes eas-cli@latest whoami`. (Interactive machines can `eas login`.) |
 | `simulator:start`/`build`: no linked project / missing `projectId` | A fresh `create-expo-app` isn't linked to EAS | `npx --yes eas-cli@latest init` to create/link it (writes `extra.eas.projectId`). |
 | `prebuild`/`eas build` prompts for or fails on a missing **iOS bundle identifier** | A fresh app often has no `ios.bundleIdentifier` | Set it in app config (e.g. `dev.<owner>.<slug>`); confirm via `npx expo config --json` (may live in `app.config.js`). |
@@ -29,6 +29,7 @@ Concrete errors seen while validating this flow, and the fix.
 | `expo start --tunnel` errors for a robot/`EXPO_TOKEN` user | The ngrok robot-user guard | Use tunnel v2: `EXPO_UNSTABLE_TUNNEL_V2=1 expo start --tunnel`. |
 | Unexpected charges / a session you forgot | `start --non-interactive` does NOT auto-stop | Always `npx --yes eas-cli@latest simulator:stop --id <id>`. List leftovers with `npx --yes eas-cli@latest simulator:list`. |
 | Screenshot shows **old content** / my recent edits don't appear | Running a **release build (Mode A/B)** whose JS was baked in *before* your edits — typically a reused/stale build | A/B reflect code at build time, not now. **Rebuild** (ensure the build's fingerprint matches current source), or use **Mode C** (dev + Metro) so live edits show via Fast Refresh. The screenshot itself is fresh — it's the build that's stale. (`9:41` in the status bar is the sim default, not staleness.) |
+| (argent) Every `argent run`/`tools` call returns `401 Unauthorized` right after linking | `argent link` without `--yes` no-ops on an already-linked URL ("Already linked. No changes."), keeping a stale token from a previous session | Re-link with `--yes` so the new token is written — see the link command in [controllers.md](./controllers.md). |
 
 ## Performance expectations
 


### PR DESCRIPTION
## Why

Follow-up on the eas-simulator skill (#88): argent now supports remote install, and dogfooding the skill surfaced a few gaps.

## How

argent can install a local build into a remote session (tar-upload) — the skill documents this, gated on argent ≥ 0.16.0. Plus the smaller dogfood fixes (POSIX-shell note, `apps --all`, the `argent link --yes` 401 gotcha).

## Test plan

Validated argent remote install end-to-end from Cursor against a live EAS `--type argent` session on argent 0.16.0 (released today). The tar-upload fired (`Uploading … to the remote tool-server` on stderr, expected), a 106 MB Release `.app` streamed and installed in ~18s with no extra flags, the app launched and rendered on the remote iPhone 17, and drive verbs (`describe` → tap-through, screenshots) worked off the accessibility tree. Session start/env-vars/`reinstall-app` args all matched controllers.md. Cleanup (stop + dotenv reset + unlink) confirmed.

Also re-ran the earlier iOS `agent-device` drive loop (start → open → press → screenshot → stop) against a live session.

<details>
<summary>Transcript 1 — explicit tar-upload test (argent 0.16.0) for debug purposes (not a usual user prompt)</summary>

> **User:** Use the eas-simulator skill to test argent's new remote install (tar-upload, argent 0.16.0). Build/reuse a local sim `.app`, start `simulator:start --type argent --package-version 0.16.0`, install with `argent run reinstall-app`, confirm the upload line on stderr, launch + screenshot, clean up. Report whether the upload fired, the app rendered, and anything diverging from controllers.md.

**Result:** all three checked out.

1. **Build reused** — existing Release sim build (`eassimsampleapp.app`, 106 MB, `dev.gwdp.eassimsampleapp`, `iphonesimulator`); no rebuild.
2. **Session started** with `--type argent --package-version 0.16.0`; live in ~75s, wrote `ARGENT_TOOLS_URL` / `ARGENT_AUTH_TOKEN` / `EAS_SIMULATOR_SESSION_ID`, iPhone 17 (iOS 26.5) booted — exactly as controllers.md describes.
3. **Upload fired** — `reinstall-app` printed `Uploading eassimsampleapp.app to the remote tool-server...` on stderr and returned `{"reinstalled": true}`. Tar + stream of the 106 MB bundle + install: ~18s, no extra flags.
4. **Install verified** — `launch-app` → `{"launched": true}`, screen idle, screenshot showed the home screen rendering.
5. **Cleaned up** — session stopped, `.env.eas-simulator` reset (already gitignored).

**Divergences (doc-level, non-behavioral):**
- The globally installed `argent` was **0.13.0** (too old for tar-upload). Sidestepped by pinning `npx --yes @swmansion/argent@0.16.0` via `simulator:exec` rather than the global binary / `argent link`. The global-install + `link` path would have silently used 0.13.0 and failed as the doc warns. Worth a doc line: prefer a pinned `npx @swmansion/argent@<version>` when the session was started with `--package-version`.
- `simulator:start` now prints a post-link hint ("Restart your editor after linking so its Argent MCP process uses the remote session") — consistent with the doc's reload advice.

</details>

<details>
<summary>Transcript 2 — natural-language "run my app" (install + tap-through)</summary>

> **User:** Run my app on a remote iOS sim with argent, install my local build, then tap through the main screen and screenshot each step.

**Result:** app ran on a remote EAS iOS sim (iPhone 17, iOS 26.5) driven by argent; local Release build installed via `reinstall-app` (tar-upload); tapped through both screens; 5 screenshots saved; session stopped.

1. **Session** — `--type argent`, linked local argent CLI to the remote daemon, confirmed the booted iPhone 17 via `list-devices`.
2. **Install** — local Release build was newer than the last source edit, uploaded as-is via `reinstall-app`, launched `dev.gwdp.eassimsampleapp`.
3. **Tap-through** — every target came from `describe` (accessibility tree), not pixels:

| Screenshot | Step |
|---|---|
| step-1-home | Home baseline ("Welcome to Expo Again") |
| step-2-explore | Tapped **Explore** tab |
| step-3-file-routing-expanded | Expanded **File-based routing** |
| step-4-images-expanded | Expanded **Images** |
| step-5-back-home | Tapped **Home** — back to welcome |

Tab nav and both collapsibles worked. Cleanup: session stopped, dotenv reset, argent link removed. Note: Release build = JS frozen at build time; live iteration needs a dev-client build + Metro tunnel (Mode C).

</details>
