### PR TITLE
[expo-upgrade] Update versioned docs links in agent file

### DIFF
--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/skills/expo-upgrade/SKILL.md
+++ b/plugins/expo/skills/expo-upgrade/SKILL.md
@@ -75,6 +75,7 @@ These steps only apply when `ios/` and/or `android/` directories exist in the pr
 ## Housekeeping
 
 - Review release notes for the target SDK version at https://expo.dev/changelog
+- Update versioned docs links in agent instruction files (`AGENTS.md`). The default template links to `https://docs.expo.dev/versions/v<version>/`. Search for `docs.expo.dev/versions/` and bump each link to the new SDK version.
 - If using Expo SDK 54 or later, ensure react-native-worklets is installed — this is required for react-native-reanimated to work.
 - Enable React Compiler in SDK 54+ by adding `"experiments": { "reactCompiler": true }` to app.json — it's stable and recommended
 - Delete sdkVersion from `app.json` to let Expo manage it automatically
@@ -106,6 +107,7 @@ Check if package.json has excluded packages:
 ```
 
 Exclusions are often workarounds that may no longer be needed after upgrading. Review each one.
+
 ## Removing patches
 
 Check if there are any outdated patches in the `patches/` directory. Remove them if they are no longer needed.


### PR DESCRIPTION
# Why

The default template's `AGENTS.md` pins a versioned docs URL (for example, `https://docs.expo.dev/versions/v56.0.0/`), when an Expo project is created with SDK 56.

The `expo-upgrade` skill never touches the `AGENTS.md` file, so after an upgrade the agent keeps reading the old SDK's docs. Found while dogfooding an SDK 56 to 57 upgrade, and had to bump the version manually so an agent reads SDK 57 documentation.

# How

- Added a Housekeeping bullet to `expo-upgrade/SKILL.md`: search for `docs.expo.dev/versions/` in agent instruction files (`AGENTS.md`) and bump each link to the new SDK version.
- Bumped all three plugin manifests to 1.8.1.