### PR TITLE
feat(expo): natural-language telemetry toggle — harden trigger phrasings

### DIFF
--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/README.md
+++ b/plugins/expo/README.md
@@ -89,7 +89,7 @@ Skills come in two groups so the free vs paid boundary stays clear: open-source 
 
 ## Usage telemetry & feedback
 
-**Off by default** — nothing is sent unless you turn telemetry on. When enabled (Claude Code only), the plugin sends anonymous usage events — the skill name, platform, and a hash of a random local install id — never code, prompts, file paths, or personal data. Ask your agent to **"enable Expo skills telemetry"** to opt in (or set `EXPO_SKILLS_TELEMETRY=1`); turn off with `EXPO_SKILLS_TELEMETRY=0` / `DO_NOT_TRACK=1`. Feedback on a skill goes through the **expo-skill-feedback** skill.
+**Off by default** — nothing is sent unless you turn telemetry on. When enabled (Claude Code only), the plugin sends anonymous usage events — the skill name, platform, and a hash of a random local install id — never code, prompts, file paths, or personal data. Ask your agent to **"enable Expo skills telemetry"** to opt in and **"disable Expo skills telemetry"** to turn it off — no command or path to remember. Env vars work too: `EXPO_SKILLS_TELEMETRY=1` enables, `EXPO_SKILLS_TELEMETRY=0` / `DO_NOT_TRACK=1` disables. Feedback on a skill goes through the **expo-skill-feedback** skill.
 
 ## License
 

--- a/plugins/expo/skills/expo-skill-feedback/SKILL.md
+++ b/plugins/expo/skills/expo-skill-feedback/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: expo-skill-feedback
-description: Framework (OSS). Submit feedback on an Expo skill — or on Expo itself — or turn the bundled anonymous usage telemetry on or off (off by default / opt-in; the user saying "enable Expo skills telemetry" in conversation is the switch). Use when an Expo skill was useful, confusing, broken, missing context, or worth improving; when something fell short because of Expo (an SDK bug or confusing framework behavior) rather than the skill; or when the user wants to enable, turn on, opt in to, disable, turn off, opt out of, check the status of, or understand the anonymous usage tracking these skills can send.
+description: Framework (OSS). Submit feedback on an Expo skill — or on Expo itself — or turn the bundled anonymous usage telemetry on or off (off by default / opt-in; the user saying "enable Expo skills telemetry" in conversation is the switch). Use when an Expo skill was useful, confusing, broken, missing context, or worth improving; when something fell short because of Expo (an SDK bug or confusing framework behavior) rather than the skill; or for any request about the telemetry, analytics, usage data, or tracking these Expo skills themselves send — enable, turn on, opt in, disable, turn off, opt out, "stop tracking me", "do not track", check whether it's on, or what anonymous data gets collected. Not for adding analytics or tracking to the user's own app.
 ---
 
 # Expo Skill Feedback
@@ -28,6 +28,9 @@ node "${CLAUDE_PLUGIN_ROOT}/skills/expo-skill-feedback/scripts/skill-feedback.cj
 - `--about`: `skill` (default) · `expo` (the issue is Expo itself, not the skill)
 - `--dry-run` prints the payload without sending
 
+If `${CLAUDE_PLUGIN_ROOT}` is not set (agents other than Claude Code), the scripts live
+in this skill's own `scripts/` directory — resolve them relative to this file.
+
 Never include secrets, source code, long prompts, or stack traces.
 
 If the command refuses because telemetry is off, don't drop the feedback — ask the user
@@ -44,9 +47,10 @@ answers yes when you offer — run:
 node "${CLAUDE_PLUGIN_ROOT}/skills/expo-skill-feedback/scripts/telemetry.cjs" --on
 ```
 
-`--off` turns it off again. When the user asks whether telemetry is on, run `--status`
-and relay its output — don't answer from memory; env vars and CI can override the saved
-state. Env equivalents: `EXPO_SKILLS_TELEMETRY=1` to enable, `=0` or `DO_NOT_TRACK=1` to
+When the user asks to stop — "disable telemetry", "turn off tracking", "do not track" —
+run `--off` and confirm from its output. When they ask whether telemetry is on, run
+`--status` and relay its output — don't answer from memory; env vars and CI can override
+the saved state. Env equivalents: `EXPO_SKILLS_TELEMETRY=1` to enable, `=0` or `DO_NOT_TRACK=1` to
 disable; CI never sends.
 
 **Never enable it on your own.** If a feedback send was refused because telemetry is off,

--- a/plugins/expo/skills/expo-skill-feedback/agents/openai.yaml
+++ b/plugins/expo/skills/expo-skill-feedback/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Expo Skill Feedback"
   short_description: "Send anonymous feedback on an Expo skill, or turn the opt-in usage telemetry on or off (off by default)"
-  default_prompt: "Use $expo-skill-feedback to rate an Expo skill (useful, confusing, bug, idea) with a short anonymous note, or to enable, disable, or check the status of Expo skills telemetry."
+  default_prompt: "Use $expo-skill-feedback to rate an Expo skill (useful, confusing, bug, idea) with a short anonymous note, or for any request about the telemetry, analytics, or tracking these skills themselves send — enable, disable, opt out, \"stop tracking me\", or check its status. Not for adding analytics to the user's own app."


### PR DESCRIPTION
## Summary

Expo skills telemetry is designed to be toggled through natural language — you tell your agent "enable/disable Expo skills telemetry" and it runs the path-heavy `telemetry.cjs` for you, since nobody should type `node ~/.claude/plugins/.../telemetry.cjs` by hand. This PR hardens that front door: the `expo-skill-feedback` skill now triggers on the phrasings people actually use, the docs present the agent as the switch in **both** directions, and agents that don't substitute `${CLAUDE_PLUGIN_ROOT}` get a working fallback.

## Changes

| Surface | Change |
|---|---|
| `expo-skill-feedback` description | Telemetry branch now catches "stop tracking me", "do not track", analytics / usage-data wording, and status / what-data-is-collected asks — scoped to what these skills *themselves* send, with an explicit exclusion: "Not for adding analytics or tracking to the user's own app" |
| `SKILL.md` body | Disable phrasings explicitly map to `--off` (previously only the enable path was spelled out); fallback note for agents other than Claude Code, where `${CLAUDE_PLUGIN_ROOT}` isn't substituted |
| `agents/openai.yaml` | Codex trigger metadata synced to the same phrasings + exclusion |
| Plugin README | Turn-off is now also "ask your agent" (was env-var-only), symmetric with turn-on |
| Plugin manifests (×3) | Version 1.8.1 → 1.8.2 |

## Validation

- `bun scripts/check-skill-limits.ts`, `claude plugin validate` (marketplace + plugin), and JSON parse checks: all green.
- Blind trigger eval: 3 independent judges routed 12 realistic phrasings against the full 21-skill catalog — **12/12 correct**, including the hard positives ("stop tracking me", bare "do not track") and the negatives ("add posthog analytics to my expo app" → `expo-examples`; "track user events in my app" → none; "my app crashes on launch" → none). Judges twice cited the new exclusion clause as what prevented mis-routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)