### PR TITLE
Add expo-experiments plugin for skills targeting non-finalized APIs

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -15,6 +15,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Developer Tools"
+    },
+    {
+      "name": "expo-experiments",
+      "source": {
+        "source": "local",
+        "path": "./plugins/expo-experiments"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,6 +14,11 @@
       "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps."
     },
     {
+      "name": "expo-experiments",
+      "source": "./plugins/expo-experiments",
+      "description": "Experimental Expo skills for APIs that are not finalized. Skills graduate to the expo plugin when stable."
+    },
+    {
       "name": "expo-app-design",
       "source": "./plugins/expo",
       "description": "[Deprecated] Use the \"expo\" plugin instead. Build robust, productivity apps with Expo."

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -13,6 +13,11 @@
       "name": "expo",
       "source": "./plugins/expo",
       "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps."
+    },
+    {
+      "name": "expo-experiments",
+      "source": "./plugins/expo-experiments",
+      "description": "Experimental Expo skills for APIs that are not finalized. Skills graduate to the expo plugin when stable."
     }
   ]
 }

--- a/plugins/expo-experiments/.claude-plugin/plugin.json
+++ b/plugins/expo-experiments/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "expo-experiments",
+  "version": "0.1.0",
+  "description": "Experimental Expo skills for APIs that are not finalized. Skills here may change or be retired, and graduate to the expo plugin when stable.",
+  "author": {
+    "name": "Expo Team",
+    "email": "support@expo.dev"
+  }
+}

--- a/plugins/expo-experiments/.codex-plugin/plugin.json
+++ b/plugins/expo-experiments/.codex-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "expo-experiments",
+  "version": "0.1.0",
+  "description": "Experimental Expo skills for APIs that are not finalized. Skills here may change or be retired, and graduate to the expo plugin when stable.",
+  "author": {
+    "name": "Expo Team",
+    "email": "support@expo.dev"
+  }
+}

--- a/plugins/expo-experiments/.cursor-plugin/plugin.json
+++ b/plugins/expo-experiments/.cursor-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "expo-experiments",
+  "version": "0.1.0",
+  "description": "Experimental Expo skills for APIs that are not finalized. Skills here may change or be retired, and graduate to the expo plugin when stable.",
+  "author": {
+    "name": "Expo Team",
+    "email": "support@expo.dev"
+  }
+}

--- a/plugins/expo-experiments/README.md
+++ b/plugins/expo-experiments/README.md
@@ -1,0 +1,26 @@
+# Expo Experiments
+
+Experimental skills from the Expo team, for Expo APIs that are still evolving and not covered by stability guarantees.
+
+This plugin is separate from the main `expo` plugin on purpose:
+
+- Skills here target **experimental or pre-release Expo APIs**. Their guidance can change or become outdated as those APIs evolve.
+- Skills may be **rewritten, renamed, or removed** between versions without the compatibility care the `expo` plugin gets.
+- When the underlying API stabilizes, its skill **graduates to the `expo` plugin** and is removed from here.
+
+If you are not deliberately using an experimental Expo API, install the main `expo` plugin instead.
+
+## Installation
+
+```text
+/plugin marketplace add expo/skills
+/plugin install expo-experiments
+```
+
+## Skills Included
+
+None yet. Skills land here through their own pull requests.
+
+## License
+
+MIT


### PR DESCRIPTION
# Why

Follow-up to the discussion in #109: skills for experimental Expo APIs (like the Expo Modules API 2.0 macros) should not ship inside the official `expo` plugin while the underlying API can still change. This adds a dedicated `expo-experiments` plugin as the home for such skills, per the suggestion there.

# What

An empty plugin scaffold, no skills yet (the first one arrives via #109 once this merges):

- `plugins/expo-experiments/` with manifests for Claude Code, Codex, and Cursor at version `0.1.0` (the 0.x reflects the experimental contract).
- A plugin README stating the rules: skills here target non-finalized APIs, may change or be retired, and graduate to `expo` when the API stabilizes.
- Marketplace entries in all three catalogs (`.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`, `.cursor-plugin/marketplace.json`).

Deliberately **not** included, so these are recorded decisions rather than gaps:

- No `skills.sh.json` changes here; the "Experimental" grouping lands together with the first skill in #109 (that catalog has no exclude mechanism, so experimental skills are listed there under an explicit label).
- No coverage by `check-plugin-version-bump.ts` or the skill-eval CI, both of which guard `plugins/expo` only. Less ceremony seems right for an experimental channel, but extending either is a small change if preferred.
- No MCP config; skills that need it can bring it when they land.

# Test Plan

- `claude plugin validate .` and `claude plugin validate ./plugins/expo-experiments` pass.
- All six edited/created JSON files parse (`python3 -m json.tool`).
- Codex marketplace registration verified in an isolated `CODEX_HOME` (`codex plugin marketplace add` succeeds).
- `bun scripts/check-skill-limits.ts` and `bun scripts/check-plugin-version-bump.ts origin/main` pass.