### PR TITLE
[throwaway] CI trigger test for skill-eval-ci.yml (re-test post #111)

### DIFF
--- a/plugins/expo/skills/expo-project-structure/SKILL.md
+++ b/plugins/expo/skills/expo-project-structure/SKILL.md
@@ -104,3 +104,5 @@ Agent instructions live at the repo root — `AGENTS.md` / `CLAUDE.md`, with pro
 ---
 
 Based on [Expo app folder structure best practices](https://expo.dev/blog/expo-app-folder-structure-best-practices) by Kadi Kraman. For `src/` precedence and alias mechanics, see the [Expo docs](https://docs.expo.dev/router/reference/src-directory/).
+
+<!-- ci-test: re-verifying skill-eval-ci.yml fires automatically post-#111 (throwaway, safe to ignore/revert) -->


### PR DESCRIPTION
Throwaway PR to confirm `skill-eval-ci.yml`'s `pull_request` trigger fires automatically and the `comment` job posts successfully, now that #111 (main-vs-PR comparison + baseline caching, plus the two bugs found and fixed during that PR's own testing) is merged into `main`.

Will close/revert once confirmed.