### PR TITLE
[skills] add Kimi Code plugin installation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ This repository contains official Expo AI agent skills. The primary distribution
     marketplace.json        # Codex marketplace catalog
 .cursor-plugin/
   marketplace.json          # Cursor marketplace catalog
+kimi.plugin.json             # Kimi Code manifest for repository URL installs
 plugins/
   expo/
     .claude-plugin/
@@ -20,6 +21,7 @@ plugins/
       plugin.json           # Codex plugin manifest
     .cursor-plugin/
       plugin.json           # Cursor plugin manifest
+    kimi.plugin.json         # Kimi Code manifest for direct local installs
     .mcp.json               # Claude Code and Codex MCP server configuration
     mcp.json                # Cursor MCP server configuration
     skills/
@@ -201,7 +203,7 @@ Follow the full guide in `CONTRIBUTING.md`. In short:
 3. Add focused reference files under `references/` when the skill needs more detail than belongs in the main `SKILL.md`, scripts under `scripts/` only for reusable logic, and `agents/openai.yaml` for Codex triggering.
 4. Add the canonical feedback block with `bun scripts/check-skill-limits.ts --fix-feedback`; CI verifies that its subject matches the skill name.
 5. Register the skill in every catalog: `skills.sh.json`, `plugins/expo/README.md`, `plugins/expo/skills/README.md`, and the root `README.md`.
-6. Bump the version in all three plugin manifests together (they must match and be greater than main; CI-enforced).
+6. Bump the version in all five plugin manifests together (they must match and be greater than main; CI-enforced).
 7. Keep the skill under the existing `expo` plugin unless there is a clear distribution reason to create a new plugin.
 
 ## Testing Plugins
@@ -224,6 +226,8 @@ python3 -m json.tool .cursor-plugin/marketplace.json >/dev/null
 python3 -m json.tool plugins/expo/.claude-plugin/plugin.json >/dev/null
 python3 -m json.tool plugins/expo/.codex-plugin/plugin.json >/dev/null
 python3 -m json.tool plugins/expo/.cursor-plugin/plugin.json >/dev/null
+python3 -m json.tool kimi.plugin.json >/dev/null
+python3 -m json.tool plugins/expo/kimi.plugin.json >/dev/null
 python3 -m json.tool plugins/expo/.mcp.json >/dev/null
 python3 -m json.tool plugins/expo/mcp.json >/dev/null
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,12 +115,19 @@ CI fails if the block is missing, has drifted, or names the wrong skill.
 
 ### 10. Bump the plugin version
 
-Bump `version` in **all three** manifests together - they must match each other and be greater
+Bump `version` in **all five** manifests together - they must match each other and be greater
 than `main`. CI enforces this.
 
+- `kimi.plugin.json`
 - `plugins/expo/.claude-plugin/plugin.json`
 - `plugins/expo/.codex-plugin/plugin.json`
 - `plugins/expo/.cursor-plugin/plugin.json`
+- `plugins/expo/kimi.plugin.json`
+
+Kimi Code needs the repository-root manifest for GitHub URL installs because it downloads the
+whole repository and does not select a nested plugin directory. The second Kimi manifest keeps
+`plugins/expo` directly installable from a local absolute path. Keep their metadata and MCP
+configuration identical; only their relative `skills` paths differ.
 
 ### 11. Validate before opening a PR
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Skills give AI agents focused Expo knowledge: when to use Expo APIs, how to stru
 
 ## Installation
 
-For Claude Code or Codex, install the plugin so updates are handled by the official plugin marketplace. For Cursor, OpenCode, and other AI coding agents, use the skills CLI.
+For Claude Code or Codex, install the plugin so updates are handled by the official plugin marketplace. Kimi Code can install the Expo plugin directly from this GitHub repository. For Cursor, OpenCode, and other AI coding agents, use the skills CLI.
 
 | Path | Best for |
 | --- | --- |
-| Plugin install | Claude Code or Codex, with updates handled by their official plugin marketplaces. |
+| Plugin install | Claude Code or Codex via their official plugin marketplaces, or Kimi Code directly from GitHub. |
 | Skills CLI | Cursor, OpenCode, GitHub Copilot, Windsurf, Gemini, Cline, AMP, Factory Droid, Antigravity, Kiro CLI, and other AI coding agents. |
 
 ### Skills CLI
@@ -61,9 +61,15 @@ codex plugin add expo@openai-curated
 
 You can also open `/plugins` in Codex and install `expo` from the OpenAI-curated marketplace.
 
+### Kimi Code
+
+```text
+/plugins install https://github.com/expo/skills
+```
+
 ## Updating
 
-Claude Code and Codex plugin installs are updated through their official plugin marketplaces.
+Claude Code and Codex plugin installs are updated through their official plugin marketplaces. To update a Kimi Code install, run the same `/plugins install https://github.com/expo/skills` command again, then `/reload`.
 
 For skills CLI installs, update installed skills with:
 
@@ -140,17 +146,17 @@ Skills for Expo APIs that are not finalized. Content may change or be retired; s
 
 Skills teach an agent how Expo work gets done. The [Expo MCP server](https://docs.expo.dev/eas/ai/mcp/) gives it live access to actually do that work: read the latest Expo docs on demand, install compatible dependencies with `npx expo install`, trigger and monitor EAS builds and workflows, pull crash data from TestFlight, and screenshot a running app in the simulator.
 
-The `expo` plugin bundles this MCP configuration, so Claude Code and Codex plugin installs wire it up automatically. For other agents, or to add it on its own, follow the [Expo MCP setup guide](https://docs.expo.dev/eas/ai/mcp/).
+The `expo` plugin bundles this MCP configuration, so Claude Code, Codex, and Kimi Code plugin installs wire it up automatically. For other agents, or to add it on its own, follow the [Expo MCP setup guide](https://docs.expo.dev/eas/ai/mcp/).
 
 ## FAQ
 
 ### Which AI coding agents are supported?
 
-Use `npx skills@latest add expo/skills --skill '*'` for Cursor, OpenCode, GitHub Copilot, Windsurf, Gemini, Cline, AMP, Factory Droid, Antigravity, Kiro CLI, and similar AI coding tools.
+Use the Expo plugin for Claude Code, Codex, or Kimi Code. Use `npx skills@latest add expo/skills --skill '*'` for Cursor, OpenCode, GitHub Copilot, Windsurf, Gemini, Cline, AMP, Factory Droid, Antigravity, Kiro CLI, and similar AI coding tools.
 
 ### Should I install the skills or the plugin?
 
-Use the plugin for Claude Code or Codex; it stays updated through the plugin marketplace. Use `npx skills@latest add expo/skills --skill '*'` for Cursor, OpenCode, and other AI coding agents.
+Use the plugin for Claude Code or Codex through their marketplaces, or install it directly from GitHub in Kimi Code. Use `npx skills@latest add expo/skills --skill '*'` for Cursor, OpenCode, and other AI coding agents.
 
 ### What is the source of truth?
 

--- a/kimi.plugin.json
+++ b/kimi.plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "expo",
+  "version": "1.8.6",
+  "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
+  "author": {
+    "name": "Expo Team",
+    "email": "support@expo.dev"
+  },
+  "homepage": "https://docs.expo.dev/skills/",
+  "license": "MIT",
+  "keywords": [
+    "expo",
+    "react-native",
+    "expo-router",
+    "eas",
+    "mobile",
+    "ios",
+    "android",
+    "deployment",
+    "upgrades",
+    "native-modules",
+    "app-clips",
+    "brownfield",
+    "eas-update",
+    "mcp"
+  ],
+  "skills": "./plugins/expo/skills/",
+  "mcpServers": {
+    "expo": {
+      "url": "https://mcp.expo.dev/mcp"
+    }
+  },
+  "interface": {
+    "displayName": "Expo",
+    "shortDescription": "Build, deploy, upgrade, and debug Expo and React Native apps",
+    "longDescription": "Official Expo-authored skills for building Expo Router UI, authoring API routes, configuring data fetching and styling, writing Expo native modules, adding App Clips, integrating Expo into brownfield native apps, inspecting EAS Update health, creating dev clients, upgrading Expo SDKs, using Expo MCP, and deploying Expo apps with EAS workflows, builds, hosting, TestFlight, App Store, and Play Store guidance.",
+    "developerName": "Expo",
+    "websiteURL": "https://expo.dev/"
+  }
+}

--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/kimi.plugin.json
+++ b/plugins/expo/kimi.plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "expo",
+  "version": "1.8.6",
+  "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
+  "author": {
+    "name": "Expo Team",
+    "email": "support@expo.dev"
+  },
+  "homepage": "https://docs.expo.dev/skills/",
+  "license": "MIT",
+  "keywords": [
+    "expo",
+    "react-native",
+    "expo-router",
+    "eas",
+    "mobile",
+    "ios",
+    "android",
+    "deployment",
+    "upgrades",
+    "native-modules",
+    "app-clips",
+    "brownfield",
+    "eas-update",
+    "mcp"
+  ],
+  "skills": "./skills/",
+  "mcpServers": {
+    "expo": {
+      "url": "https://mcp.expo.dev/mcp"
+    }
+  },
+  "interface": {
+    "displayName": "Expo",
+    "shortDescription": "Build, deploy, upgrade, and debug Expo and React Native apps",
+    "longDescription": "Official Expo-authored skills for building Expo Router UI, authoring API routes, configuring data fetching and styling, writing Expo native modules, adding App Clips, integrating Expo into brownfield native apps, inspecting EAS Update health, creating dev clients, upgrading Expo SDKs, using Expo MCP, and deploying Expo apps with EAS workflows, builds, hosting, TestFlight, App Store, and Play Store guidance.",
+    "developerName": "Expo",
+    "websiteURL": "https://expo.dev/"
+  }
+}

--- a/scripts/check-plugin-version-bump.ts
+++ b/scripts/check-plugin-version-bump.ts
@@ -30,6 +30,14 @@ const pluginManifests: PluginManifest[] = [
     label: "Cursor",
     path: "plugins/expo/.cursor-plugin/plugin.json",
   },
+  {
+    label: "Kimi (repository root)",
+    path: "kimi.plugin.json",
+  },
+  {
+    label: "Kimi (plugin directory)",
+    path: "plugins/expo/kimi.plugin.json",
+  },
 ];
 
 const versionedPluginPaths = [
@@ -37,12 +45,17 @@ const versionedPluginPaths = [
   "plugins/expo/.claude-plugin/plugin.json",
   "plugins/expo/.codex-plugin/plugin.json",
   "plugins/expo/.cursor-plugin/plugin.json",
+  "kimi.plugin.json",
+  "plugins/expo/kimi.plugin.json",
   "plugins/expo/.mcp.json",
   "plugins/expo/mcp.json",
 ];
 
 function runGit(args: string[]) {
-  return execFileSync("git", args, { encoding: "utf8" }).trim();
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
 }
 
 function getChangedFiles() {
@@ -134,12 +147,12 @@ const rows: VersionRow[] = pluginManifests.map((manifest) => ({
 
 const errors: string[] = [];
 const currentVersions = new Set(rows.map((row) => row.currentVersion));
-const baseVersions = new Set(rows.map((row) => row.baseVersion));
+const baseVersions = new Set(
+  rows.flatMap((row) => (row.baseVersion === undefined ? [] : [row.baseVersion]))
+);
 
 for (const row of rows) {
-  if (row.baseVersion === undefined) {
-    errors.push(`${row.label} manifest is missing or has no version on main (${row.path}).`);
-  } else if (!isSemver(row.baseVersion)) {
+  if (row.baseVersion !== undefined && !isSemver(row.baseVersion)) {
     errors.push(`${row.label} has an invalid semver version on main: ${formatVersion(row.baseVersion)}`);
   }
 
@@ -151,15 +164,18 @@ for (const row of rows) {
 }
 
 if (baseVersions.size !== 1) {
-  errors.push("The Claude, Codex, and Cursor plugin versions on main are not in sync.");
+  errors.push("The plugin versions on main are not in sync.");
 }
 
 if (currentVersions.size !== 1) {
-  errors.push("The Claude, Codex, and Cursor plugin versions in this PR must match.");
+  errors.push("All plugin manifest versions in this PR must match.");
 }
 
 if (errors.length === 0) {
   for (const row of rows) {
+    if (row.baseVersion === undefined) {
+      continue;
+    }
     if (semver.order(row.currentVersion as string, row.baseVersion as string) <= 0) {
       errors.push(`${row.label} version must be greater than main (${formatVersion(row.baseVersion)}).`);
     }
@@ -172,7 +188,7 @@ const markdown = [
   "",
   errors.length === 0
     ? "Passed. Versioned Expo plugin files changed and all plugin manifests were bumped together."
-    : "Failed. Versioned Expo plugin files changed, so the Claude, Codex, and Cursor plugin manifests must all be bumped together.",
+    : "Failed. Versioned Expo plugin files changed, so all plugin manifests must be bumped together.",
   "",
   formatVersionRows(rows),
   "",


### PR DESCRIPTION
## Summary
- Add Kimi Code manifests at the repository and Expo plugin roots for GitHub and local installs, including Expo MCP configuration.
- Document the `/plugins install https://github.com/expo/skills` flow and update contributor guidance.
- Synchronize all plugin manifests at 1.8.6 and extend CI version enforcement to Kimi.

## Testing
- `bun scripts/check-skill-limits.ts`; `bun scripts/check-plugin-version-bump.ts origin/main`; `claude plugin validate ./plugins/expo`; Kimi Code 0.29.1 local and archive installs.