### PR TITLE
Add deep linking coverage to the expo-router skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Free, open-source Expo SDK and React Native skills.
 | Skill | Use it for |
 | --- | --- |
 | `expo-project-structure` | Folder structure for a new Expo app: `src/` layout, routes-only `app/`, screens, server code, platform-specific files. |
-| `expo-router` | Expo Router navigation: file-based routes, links, native stacks, modals, sheets, native tabs, and headers. |
+| `expo-router` | Expo Router navigation: file-based routes, links, native stacks, modals, sheets, native tabs, headers, and deep linking. |
 | `expo-native-ui` | Native-feeling screen styling, semantic colors, controls, icons, media, animations, and visual effects. |
 | `expo-ui` | `@expo/ui` native components: universal cross-platform first, with SwiftUI and Jetpack Compose for platform-specific needs. |
 | `expo-data-fetching` | API calls, React Query, SWR, caching, offline support, and Expo Router data loaders. |

--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/README.md
+++ b/plugins/expo/README.md
@@ -66,7 +66,7 @@ Skills come in two groups so the free vs paid boundary stays clear: open-source 
 ### Framework (open source)
 
 - **expo-project-structure** - Recommended folder structure for new Expo projects
-- **expo-router** - Navigation and routing: file-based routes, links, native stacks, modals, sheets, native tabs, and headers
+- **expo-router** - Navigation and routing: file-based routes, links, native stacks, modals, sheets, native tabs, headers, and deep linking
 - **expo-native-ui** - Build beautiful native-feeling screens: styling, semantic colors, controls, icons, media, animations, and visual effects
 - **expo-ui** - Native UI with @expo/ui: universal cross-platform components first, with SwiftUI and Jetpack Compose for platform-specific needs
 - **expo-data-fetching** - Network requests, API calls, caching, and offline support

--- a/plugins/expo/skills/README.md
+++ b/plugins/expo/skills/README.md
@@ -9,7 +9,7 @@ Free, open-source Expo SDK and React Native skills. Descriptions are prefixed `F
 | Skill | Use it for |
 | --- | --- |
 | `expo-project-structure` | Folder structure for a new Expo app: `src/` layout, routes-only `app/`, screens, server code, platform-specific files. |
-| `expo-router` | Expo Router navigation: file-based routes, links, native stacks, modals, sheets, native tabs, and headers. |
+| `expo-router` | Expo Router navigation: file-based routes, links, native stacks, modals, sheets, native tabs, headers, and deep linking. |
 | `expo-native-ui` | Native-feeling screen styling, semantic colors, controls, icons, media, animations, and visual effects. |
 | `expo-ui` | `@expo/ui` native components: universal cross-platform first, plus SwiftUI and Jetpack Compose. |
 | `expo-data-fetching` | API calls, React Query, SWR, caching, offline support, and Expo Router data loaders. |

--- a/plugins/expo/skills/expo-router/SKILL.md
+++ b/plugins/expo/skills/expo-router/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: expo-router
-description: Framework (OSS). Navigation and routing for Expo Router. Covers file-based routes, groups and dynamic routes, folder organization, Link with previews and context menus, native Stack, page titles, modals and form sheets, NativeTabs, headers and toolbars, and header search bars.
-version: 1.0.1
+description: Framework (OSS). Navigation and routing for Expo Router. Covers file-based routes, groups and dynamic routes, folder organization, Link with previews and context menus, native Stack, page titles, modals and form sheets, NativeTabs, headers and toolbars, header search bars, and deep linking setup - custom URL schemes, iOS universal links, Android app links, and +native-intent URL rewriting.
+version: 1.1.0
 license: MIT
 ---
 
@@ -21,6 +21,7 @@ references/
   form-sheet.md          Form sheets in expo-router: configuration, footers and background interaction.
   search.md              Search bar with headers, useSearch hook, filtering patterns
   zoom-transitions.md    Apple Zoom: fluid zoom transitions with Link.AppleZoom (iOS 18+)
+  linking.md             Deep linking: custom schemes, iOS universal links, Android app links, +native-intent, testing
 ```
 
 ## Code Style
@@ -37,6 +38,13 @@ See `./references/route-structure.md` for detailed route conventions.
 - Routes belong in the `app` directory.
 - Never co-locate components, types, or utilities in the app directory. This is an anti-pattern.
 - Ensure the app always has a route that matches "/", it may be inside a group route.
+
+## Deep Linking
+
+See `./references/linking.md` before configuring schemes, universal links, or app links.
+
+- Every route is deep-linkable automatically; never write a React Navigation `linking` config or `NavigationContainer`.
+- `scheme`, `associatedDomains`, and `intentFilters` are native config: rebuild the dev build after changes, and never test them in Expo Go.
 
 ## Library Preferences
 

--- a/plugins/expo/skills/expo-router/agents/openai.yaml
+++ b/plugins/expo/skills/expo-router/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Expo Router"
-  short_description: "Navigate and structure Expo Router apps: file-based routes, links, native stacks, modals, sheets, native tabs, headers, and search"
-  default_prompt: "Use $expo-router to structure file-based routes, wire up navigation with Link previews and context menus, configure native Stack screens, modals, form sheets, NativeTabs, headers, toolbars, and search bars."
+  short_description: "Navigate and structure Expo Router apps: file-based routes, links, native stacks, modals, sheets, native tabs, headers, search, and deep linking"
+  default_prompt: "Use $expo-router to structure file-based routes, wire up navigation with Link previews and context menus, configure native Stack screens, modals, form sheets, NativeTabs, headers, toolbars, and search bars, and set up deep linking with custom URL schemes, iOS universal links, and Android app links."

--- a/plugins/expo/skills/expo-router/references/linking.md
+++ b/plugins/expo/skills/expo-router/references/linking.md
@@ -1,0 +1,120 @@
+# Deep Linking: Schemes, Universal Links, and App Links
+
+Expo Router deep links every route automatically: the URL path is the route path, on cold start
+and while running. Do not write a `linking` config, `prefixes`, or a `NavigationContainer` — that
+is React Navigation setup. In SDK 56+ expo-router no longer depends on React Navigation; migrate
+old linking code with `npx expo-codemod sdk-56-expo-router-react-navigation-replace ./src` and
+import any remaining React Navigation APIs from `expo-router/react-navigation`.
+
+Add `app/+not-found.tsx` so unmatched deep links land on a graceful screen instead of an error.
+
+Everything below is native config: rebuild the development build after each change
+(`npx expo run:ios` / `run:android` or EAS Build). Expo Go only handles `exp://` links with
+limited behavior — never test scheme or universal-link changes in Expo Go.
+
+## Custom scheme (myapp://)
+
+```json
+{ "expo": { "scheme": "myapp" } }
+```
+
+Prebuild generates the iOS `CFBundleURLTypes` entry and the Android intent filter — do not add
+the custom scheme to `intentFilters` yourself.
+
+Reading the URL in JS is rarely needed (the router navigates for you). When it is, use
+`expo-linking`: `useLinkingURL()` (preferred over `useURL()`) for the current URL,
+`Linking.createURL(path)` to build outgoing URLs (OAuth redirect URIs — correct in dev builds and
+Expo Go), `Linking.parse(url)` for components. `Linking.makeUrl` no longer exists.
+
+## iOS Universal Links (https:// opens the app)
+
+1. Host an `apple-app-site-association` file (no extension, HTTPS, 200 without redirects,
+   `application/json` content type, ≤128KB) at
+   `https://<domain>/.well-known/apple-app-site-association`. With Expo Router web / EAS Hosting,
+   put it in `public/.well-known/`. Check with `curl -i` — some hosts serve extensionless files
+   with the wrong content type.
+
+```json
+{
+  "applinks": {
+    "details": [{ "appIDs": ["<TEAM_ID>.<bundleIdentifier>"], "components": [{ "/": "/records/*" }] }]
+  }
+}
+```
+
+2. Add associated domains to app config — no `https://` prefix (most common mistake):
+
+```json
+{ "expo": { "ios": { "associatedDomains": ["applinks:example.com"] } } }
+```
+
+3. EAS Build registers the `com.apple.developer.associated-domains` entitlement automatically
+   (requires a paid Apple Developer account). Bare projects without CNG add it to the
+   `.entitlements` file manually.
+4. iOS fetches the AASA on install — real devices go through Apple's CDN, which caches for hours,
+   so AASA changes are not instant. During development, reinstall the app after AASA changes.
+   `npx setup-safari` can bootstrap the Apple-side registration.
+
+## Android App Links (https:// opens the app)
+
+1. Add a verified intent filter to app config — `autoVerify: true` is required:
+
+```json
+{
+  "expo": {
+    "android": {
+      "intentFilters": [{
+        "action": "VIEW",
+        "autoVerify": true,
+        "data": [{ "scheme": "https", "host": "example.com", "pathPrefix": "/records" }],
+        "category": ["BROWSABLE", "DEFAULT"]
+      }]
+    }
+  }
+}
+```
+
+2. Host `https://<domain>/.well-known/assetlinks.json` (`public/.well-known/` on Expo Router web):
+
+```json
+[{
+  "relation": ["delegate_permission/common.handle_all_urls"],
+  "target": {
+    "namespace": "android_app",
+    "package_name": "<androidPackage>",
+    "sha256_cert_fingerprints": ["<SHA256>"]
+  }
+}]
+```
+
+3. List every signing key's fingerprint: `eas credentials -p android` (SHA256 Fingerprint), the
+   Play Console App Signing key when Play manages signing, and for local debug builds
+   `keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android`
+   — without the debug fingerprint, verification fails for `expo run:android` builds.
+4. Verification after install can take 20+ seconds. On Android 12+, check it with
+   `adb shell pm get-app-links <androidPackage>` (expect `verified`).
+
+## Rewriting incoming URLs
+
+To normalize third-party or legacy URLs before the router sees them, create `app/+native-intent.tsx`:
+
+```tsx
+export function redirectSystemPath({ path, initial }: { path: string; initial: boolean }) {
+  if (path.startsWith('/legacy/')) return path.replace('/legacy/', '/records/');
+  return path;
+}
+```
+
+## Testing
+
+```sh
+npx uri-scheme open "myapp://records/12" --ios      # or --android
+xcrun simctl openurl booted "https://example.com/records/12"
+adb shell am start -a android.intent.action.VIEW -c android.intent.category.BROWSABLE -d "https://example.com/records/12"
+```
+
+Universal/App links only open the app from real taps (Notes, Messages, another app) — typing the
+URL in Safari's address bar intentionally shows a banner instead; that is not a broken setup.
+
+For current SDK details beyond this file, consult the Expo docs MCP server bundled with this
+plugin (search for "universal links", "app links", or "linking").


### PR DESCRIPTION
## Summary

- **expo-router**: new `references/linking.md` covering custom URL schemes, iOS universal links, Android app links, `+native-intent` URL rewriting, and testing; new Deep Linking section and updated trigger description in `SKILL.md` (1.0.1 → 1.1.0); Codex `openai.yaml` metadata and catalog rows (root/plugin/skills READMEs) synced.
- **plugin manifests**: Claude/Codex/Cursor bumped together to 1.8.6 (main is at 1.8.5).

## Validation

- `bun scripts/check-skill-limits.ts` ✓
- `bun scripts/check-plugin-version-bump.ts origin/main` ✓ (1.8.6 > 1.8.5)
- `claude plugin validate ./plugins/expo` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)