### PR TITLE
[eas-simulator] always pass --name to simulator:start

### DIFF
--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/skills/eas-simulator/SKILL.md
+++ b/plugins/expo/skills/eas-simulator/SKILL.md
@@ -66,7 +66,8 @@ A session is: **start → (install your app) → drive → stop.** `eas-cli` own
 ```bash
 # 1. Start a session (boots the remote sim + agent-device daemon; writes .env.eas-simulator).
 printf '# managed by eas-cli\n' > .env.eas-simulator   # clear any stale session first
-npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive
+npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive \
+  --name "checkout flow screenshots"   # always name it — see 'Always name the session'
 #    Then confirm it's live: simulator:get --json → status IN_PROGRESS (bounded poll in run-your-app.md).
 
 # 2. Drive it through `exec` (loads the session env, then runs the command you give it).
@@ -89,14 +90,33 @@ To **watch** it live, hand the user the `webPreviewUrl` that `start` prints (an 
 
 `start` also prints a job-run URL.
 
+## Always name the session
+
+Pass `--name "<description>"` on every `simulator:start`. Without it the session is `unnamed`, and a list of unnamed sessions on expo.dev is unreadable. The name appears in `simulator:list`, `simulator:get`, and on expo.dev, so write it for a **human reading the list days later** — not for you during this run.
+
+Write what the session is *for*, in a few plain words:
+
+```bash
+--name "checkout flow screenshots"     # what you did
+--name "dev build — dark mode fix"     # what you were testing
+--name "login repro for issue 412"     # why it exists
+```
+
+Rules:
+- Derive it from the user's request, not from the mode or the tooling. `Mode C session`, `agent-device ios`, and `test` say nothing.
+- Keep it short (a few words) and specific. Include a ticket or PR number when there is one.
+- No timestamps, ids, or the platform — expo.dev already shows those.
+- If the user names it, use their name as-is.
+- Sessions are per-run, so name each new one for that run. Don't reuse an old name for different work.
+
 ## Commands at a glance
 
 | Command | Purpose |
 |---|---|
-| `npx --yes eas-cli@latest simulator:start --platform ios\|android [--type agent-device\|argent\|serve-sim] [--package-version X] [--max-duration-minutes N] [--non-interactive] [--json]` | Create a session; boot the sim + controller; write `.env.eas-simulator`; print `webPreviewUrl` + job-run URL. **`--json` suppresses the `.env.eas-simulator` write** — omit it for the `exec` flow, or set the env yourself from `remoteConfig`. |
+| `npx --yes eas-cli@latest simulator:start --platform ios\|android --name "<description>" [--type agent-device\|argent\|serve-sim] [--package-version X] [--max-duration-minutes N] [--non-interactive] [--json]` | Create a session; boot the sim + controller; write `.env.eas-simulator`; print `webPreviewUrl` + job-run URL. **Always pass `--name`** (see *Always name the session*). **`--json` suppresses the `.env.eas-simulator` write** — omit it for the `exec` flow, or set the env yourself from `remoteConfig`. |
 | `npx --yes eas-cli@latest simulator:exec <cmd> [args…]` | Load `.env.eas-simulator`, then run `<cmd>` with that env. The bridge to the controller. |
-| `npx --yes eas-cli@latest simulator:get [--id] [--json]` | Session status + connection details. **Use this to confirm readiness** (see *Operating principles*). |
-| `npx --yes eas-cli@latest simulator:list [--status …] [--type …] [--platform …]` | List an app's sessions |
+| `npx --yes eas-cli@latest simulator:get [--id] [--json]` | Session status + connection details, including the session `--name`. **Use this to confirm readiness** (see *Operating principles*). |
+| `npx --yes eas-cli@latest simulator:list [--status …] [--type …] [--platform …]` | List an app's sessions by name — this is what the `--name` you pass to `start` is for |
 | `npx --yes eas-cli@latest simulator:stop [--id]` | Stop a session (idempotent) |
 
 ## Running the user's app — pick a mode

--- a/plugins/expo/skills/eas-simulator/SKILL.md
+++ b/plugins/expo/skills/eas-simulator/SKILL.md
@@ -111,6 +111,8 @@ Rules:
 - If the user names it, use their name as-is.
 - Sessions are per-run, so name each new one for that run. Don't reuse an old name for different work.
 
+`--name` is newer than `simulator:start` itself, so an older installed `eas-cli` can reject it. If that happens, run via `npx --yes eas-cli@latest` or upgrade; as a last resort, retry once without `--name` (the session starts unnamed). See [references/troubleshooting.md](./references/troubleshooting.md).
+
 ## Commands at a glance
 
 | Command | Purpose |

--- a/plugins/expo/skills/eas-simulator/SKILL.md
+++ b/plugins/expo/skills/eas-simulator/SKILL.md
@@ -104,7 +104,8 @@ Write what the session is *for*, in a few plain words:
 
 Rules:
 - Derive it from the user's request, not from the mode or the tooling. `Mode C session`, `agent-device ios`, and `test` say nothing.
-- Keep it short (a few words) and specific. Include a ticket or PR number when there is one.
+- **Length: aim for 3–6 words, under ~50 characters.** A list is scanned, not read — a name that wraps in the terminal or gets clipped in a table column defeats the point. The API accepts up to **255 characters** and rejects an empty/whitespace-only name, but treat 255 as a hard ceiling you never approach, not a target. One noun phrase, no sentences.
+- Be specific within that budget. Include a ticket or PR number when there is one.
 - No timestamps, ids, or the platform — expo.dev already shows those.
 - If the user names it, use their name as-is.
 - Sessions are per-run, so name each new one for that run. Don't reuse an old name for different work.

--- a/plugins/expo/skills/eas-simulator/SKILL.md
+++ b/plugins/expo/skills/eas-simulator/SKILL.md
@@ -67,7 +67,7 @@ A session is: **start → (install your app) → drive → stop.** `eas-cli` own
 # 1. Start a session (boots the remote sim + agent-device daemon; writes .env.eas-simulator).
 printf '# managed by eas-cli\n' > .env.eas-simulator   # clear any stale session first
 npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive \
-  --name "checkout flow screenshots"   # always name it — see 'Always name the session'
+  --name "Checkout flow screenshots"   # always name it — see 'Always name the session'
 #    Then confirm it's live: simulator:get --json → status IN_PROGRESS (bounded poll in run-your-app.md).
 
 # 2. Drive it through `exec` (loads the session env, then runs the command you give it).
@@ -92,21 +92,22 @@ To **watch** it live, hand the user the `webPreviewUrl` that `start` prints (an 
 
 ## Always name the session
 
-Pass `--name "<description>"` on every `simulator:start`. Without it the session is `unnamed`, and a list of unnamed sessions on expo.dev is unreadable. The name appears in `simulator:list`, `simulator:get`, and on expo.dev, so write it for a **human reading the list days later** — not for you during this run.
+Pass `--name "<description>"` on every `simulator:start`. The name appears in `simulator:list`, `simulator:get`, and on the **Simulator sessions** page on expo.dev, where it replaces the generic title on each row. Unnamed, every row reads "Simulator session" over a random id — a wall of identical entries nobody can navigate. Write the name for a **human scanning that list days later**, not for yourself during this run.
 
 Write what the session is *for*, in a few plain words:
 
 ```bash
---name "checkout flow screenshots"     # what you did
---name "dev build — dark mode fix"     # what you were testing
---name "login repro for issue 412"     # why it exists
+--name "Checkout flow screenshots"     # what you did
+--name "Dev build — dark mode fix"     # what you were testing
+--name "Login repro for issue 412"     # why it exists
 ```
 
 Rules:
 - Derive it from the user's request, not from the mode or the tooling. `Mode C session`, `agent-device ios`, and `test` say nothing.
-- **Length: aim for 3–6 words, under ~50 characters.** A list is scanned, not read — a name that wraps in the terminal or gets clipped in a table column defeats the point. The API accepts up to **255 characters** and rejects an empty/whitespace-only name, but treat 255 as a hard ceiling you never approach, not a target. One noun phrase, no sentences.
+- **Length: aim for 3–6 words, ~40 characters, and treat 50 as the practical limit.** It renders as a single-line title in a narrow table column, so a long name clips. The API accepts up to **255 characters** and rejects an empty/whitespace-only name, but 255 is a ceiling you never approach, not a target. One noun phrase, no sentences.
 - Be specific within that budget. Include a ticket or PR number when there is one.
-- No timestamps, ids, or the platform — expo.dev already shows those.
+- **Sentence case:** capitalize the first word only, and leave identifiers in their real casing (`Dev build for expo-router v4`, `Repro for EXPO-1234`). It's a row title, so no Title Case, no all-lowercase, and no trailing period.
+- **Don't repeat what the table already shows.** Every row already displays the session id, platform, start time, duration, and who created it — so no ids, no `iOS`, no dates, no your-own-name. Spend the whole budget on what those columns can't say: the purpose.
 - If the user names it, use their name as-is.
 - Sessions are per-run, so name each new one for that run. Don't reuse an old name for different work.
 

--- a/plugins/expo/skills/eas-simulator/references/run-your-app.md
+++ b/plugins/expo/skills/eas-simulator/references/run-your-app.md
@@ -16,7 +16,7 @@ printf '# managed by eas-cli\n' > .env.eas-simulator
 # --name is required practice: it labels the session in simulator:list/get and on expo.dev.
 # Describe what the run is for, in the user's terms — see "Always name the session" in SKILL.md.
 npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive \
-  --name "checkout flow screenshots"
+  --name "Checkout flow screenshots"
 ```
 
 `start`'s own poll is unreliable, so confirm liveness with a bounded loop (boot is ~90s–15min). `get`/`exec`/`stop` default to the session in `.env.eas-simulator`, so you can omit `--id`:

--- a/plugins/expo/skills/eas-simulator/references/run-your-app.md
+++ b/plugins/expo/skills/eas-simulator/references/run-your-app.md
@@ -13,7 +13,10 @@ In all modes, the session is started the same way and driven through `npx --yes 
 printf '# managed by eas-cli\n' > .env.eas-simulator
 
 # Start (no --json, so it writes .env.eas-simulator). It boots the sim + agent-device daemon.
-npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive
+# --name is required practice: it labels the session in simulator:list/get and on expo.dev.
+# Describe what the run is for, in the user's terms — see "Always name the session" in SKILL.md.
+npx --yes eas-cli@latest simulator:start --platform ios --type agent-device --non-interactive \
+  --name "checkout flow screenshots"
 ```
 
 `start`'s own poll is unreliable, so confirm liveness with a bounded loop (boot is ~90s–15min). `get`/`exec`/`stop` default to the session in `.env.eas-simulator`, so you can omit `--id`:

--- a/plugins/expo/skills/eas-simulator/references/troubleshooting.md
+++ b/plugins/expo/skills/eas-simulator/references/troubleshooting.md
@@ -5,6 +5,7 @@ Concrete errors seen while validating this flow, and the fix.
 | Symptom | Cause | Fix |
 |---|---|---|
 | `Command simulator:start not found` | `eas-cli` too old (commands are hidden but present from ≥ 20.3.0) | Run via `npx --yes eas-cli@latest …`, or upgrade `eas-cli`. |
+| `simulator:start` rejects `--name` (e.g. `Nonexistent flag: --name`) | `eas-cli` too old — `--name` was added after `simulator:start` itself | Run via `npx --yes eas-cli@latest …`, or upgrade `eas-cli`. If you can't upgrade, retry once **without** `--name`; the session starts unnamed. |
 | `An Expo user account is required` / `whoami` shows logged-out | No browser login on a cloud/CI/headless box, or `EXPO_TOKEN` unset/invalid | Set **`EXPO_TOKEN`** (expo.dev → Account → Access Tokens) in the env; verify `npx --yes eas-cli@latest whoami`. (Interactive machines can `eas login`.) |
 | `simulator:start`/`build`: no linked project / missing `projectId` | A fresh `create-expo-app` isn't linked to EAS | `npx --yes eas-cli@latest init` to create/link it (writes `extra.eas.projectId`). |
 | `prebuild`/`eas build` prompts for or fails on a missing **iOS bundle identifier** | A fresh app often has no `ios.bundleIdentifier` | Set it in app config (e.g. `dev.<owner>.<slug>`); confirm via `npx expo config --json` (may live in `app.config.js`). |


### PR DESCRIPTION
Unnamed sessions show as `unnamed` in `eas simulator:list` / `eas simulator:get`, and every row of the **Simulator sessions** page on expo.dev reads "Simulator session" over a random id — a wall of identical entries nobody can navigate.

This teaches the skill to always pass `--name` on `simulator:start`, and to generate a name a human can recognize later — derived from what the user asked for, not from the mode or the tooling.

- **Length: aim 3–6 words / ~40 characters, 50 practical.** The name renders as a single-line title in a narrow table column. The **255-character** hard cap and the rejection of empty/whitespace-only names are verified from the GraphQL schema in `eas-cli@21.4.0` (`CreateDeviceRunSessionInput.name`); the shorter target is a style call.
- **Sentence case.** The name replaces "Simulator session" as the row title, which is itself sentence case. Identifiers keep their real casing (`Dev build for expo-router v4`).
- **No metadata the table already shows.** Each row already displays the session id, platform, start time, duration, and creator, so the whole budget goes to purpose.