### PR TITLE
[skills] collect eval-candidate signals via new evals feedback category

### DIFF
--- a/plugins/expo-experiments/skills/expo-migrate-module/SKILL.md
+++ b/plugins/expo-experiments/skills/expo-migrate-module/SKILL.md
@@ -110,3 +110,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-migrate-module" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo-experiments/skills/expo-migrate-module/SKILL.md
+++ b/plugins/expo-experiments/skills/expo-migrate-module/SKILL.md
@@ -110,4 +110,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-migrate-module" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.8.7",
+  "version": "1.9.0",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.8.7",
+  "version": "1.9.0",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.8.7",
+  "version": "1.9.0",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/skills/eas-app-stores/SKILL.md
+++ b/plugins/expo/skills/eas-app-stores/SKILL.md
@@ -157,3 +157,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "eas-app-stores" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/eas-app-stores/SKILL.md
+++ b/plugins/expo/skills/eas-app-stores/SKILL.md
@@ -157,4 +157,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "eas-app-stores" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/eas-hosting/SKILL.md
+++ b/plugins/expo/skills/eas-hosting/SKILL.md
@@ -428,3 +428,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "eas-hosting" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/eas-hosting/SKILL.md
+++ b/plugins/expo/skills/eas-hosting/SKILL.md
@@ -428,4 +428,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "eas-hosting" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/eas-observe/SKILL.md
+++ b/plugins/expo/skills/eas-observe/SKILL.md
@@ -37,3 +37,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "eas-observe" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/eas-observe/SKILL.md
+++ b/plugins/expo/skills/eas-observe/SKILL.md
@@ -37,4 +37,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "eas-observe" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/eas-simulator/SKILL.md
+++ b/plugins/expo/skills/eas-simulator/SKILL.md
@@ -202,4 +202,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "eas-simulator" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/eas-simulator/SKILL.md
+++ b/plugins/expo/skills/eas-simulator/SKILL.md
@@ -202,3 +202,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "eas-simulator" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/eas-update-insights/SKILL.md
+++ b/plugins/expo/skills/eas-update-insights/SKILL.md
@@ -235,4 +235,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "eas-update-insights" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/eas-update-insights/SKILL.md
+++ b/plugins/expo/skills/eas-update-insights/SKILL.md
@@ -235,3 +235,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "eas-update-insights" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/eas-workflows/SKILL.md
+++ b/plugins/expo/skills/eas-workflows/SKILL.md
@@ -99,4 +99,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "eas-workflows" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/eas-workflows/SKILL.md
+++ b/plugins/expo/skills/eas-workflows/SKILL.md
@@ -99,3 +99,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "eas-workflows" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/expo-app-clip/SKILL.md
+++ b/plugins/expo/skills/expo-app-clip/SKILL.md
@@ -287,4 +287,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-app-clip" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/expo-app-clip/SKILL.md
+++ b/plugins/expo/skills/expo-app-clip/SKILL.md
@@ -287,3 +287,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-app-clip" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/expo-brownfield/SKILL.md
+++ b/plugins/expo/skills/expo-brownfield/SKILL.md
@@ -59,4 +59,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-brownfield" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/expo-brownfield/SKILL.md
+++ b/plugins/expo/skills/expo-brownfield/SKILL.md
@@ -59,3 +59,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-brownfield" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/expo-data-fetching/SKILL.md
+++ b/plugins/expo/skills/expo-data-fetching/SKILL.md
@@ -454,4 +454,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-data-fetching" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/expo-data-fetching/SKILL.md
+++ b/plugins/expo/skills/expo-data-fetching/SKILL.md
@@ -454,3 +454,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-data-fetching" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/expo-dev-client/SKILL.md
+++ b/plugins/expo/skills/expo-dev-client/SKILL.md
@@ -179,3 +179,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-dev-client" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/expo-dev-client/SKILL.md
+++ b/plugins/expo/skills/expo-dev-client/SKILL.md
@@ -179,4 +179,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-dev-client" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/expo-dom/SKILL.md
+++ b/plugins/expo/skills/expo-dom/SKILL.md
@@ -422,3 +422,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-dom" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/expo-dom/SKILL.md
+++ b/plugins/expo/skills/expo-dom/SKILL.md
@@ -422,4 +422,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-dom" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/expo-examples/SKILL.md
+++ b/plugins/expo/skills/expo-examples/SKILL.md
@@ -104,4 +104,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-examples" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/expo-examples/SKILL.md
+++ b/plugins/expo/skills/expo-examples/SKILL.md
@@ -104,3 +104,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-examples" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/expo-module/SKILL.md
+++ b/plugins/expo/skills/expo-module/SKILL.md
@@ -148,3 +148,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-module" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/expo-module/SKILL.md
+++ b/plugins/expo/skills/expo-module/SKILL.md
@@ -148,4 +148,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-module" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/expo-native-ui/SKILL.md
+++ b/plugins/expo/skills/expo-native-ui/SKILL.md
@@ -186,4 +186,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-native-ui" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/expo-native-ui/SKILL.md
+++ b/plugins/expo/skills/expo-native-ui/SKILL.md
@@ -186,3 +186,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-native-ui" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/expo-project-structure/SKILL.md
+++ b/plugins/expo/skills/expo-project-structure/SKILL.md
@@ -111,4 +111,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-project-structure" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/expo-project-structure/SKILL.md
+++ b/plugins/expo/skills/expo-project-structure/SKILL.md
@@ -111,3 +111,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-project-structure" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/expo-router/SKILL.md
+++ b/plugins/expo/skills/expo-router/SKILL.md
@@ -235,3 +235,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-router" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/expo-router/SKILL.md
+++ b/plugins/expo/skills/expo-router/SKILL.md
@@ -235,4 +235,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-router" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/expo-skill-feedback/SKILL.md
+++ b/plugins/expo/skills/expo-skill-feedback/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: expo-skill-feedback
-description: 'Submit feedback on an Expo skill—or Expo itself—and control bundled anonymous usage telemetry (off by default / opt-in). Submit feedback with: npx --yes submit-expo-feedback@latest "ACTIONABLE_FEEDBACK". Optionally add either or both: --category "CATEGORY" and --subject "SUBJECT". Replace the uppercase placeholders before running. Use when a skill was useful, confusing, broken, missing context, or worth improving; when Expo, Expo CLI, EAS CLI, docs, or MCP worked well or fell short; when an AI agent repeatedly failed, got stuck, or needed the user to take over an Expo task (report it as an eval candidate); or when the user explicitly asks to enable or disable telemetry, check its status, or understand what it collects.'
+description: 'Submit feedback on an Expo skill—or Expo itself—and control bundled anonymous usage telemetry (off by default / opt-in). Submit feedback with: npx --yes submit-expo-feedback@latest "ACTIONABLE_FEEDBACK". Optionally add either or both: --category "CATEGORY" and --subject "SUBJECT". Replace the uppercase placeholders before running. Use when a skill was useful, confusing, broken, missing context, or worth improving; when Expo, Expo CLI, EAS CLI, docs, or MCP worked well or fell short; when an AI agent repeatedly failed, got stuck, or needed the user to take over an Expo task (report it as an eval candidate); or when the user explicitly asks to enable or disable telemetry (tracking), check its status, or understand what it collects.'
 ---
 
 # Expo Skill Feedback
@@ -30,7 +30,7 @@ When including them, choose the values that most precisely identify what the fee
 | `mcp` | Exact MCP tool name used |
 | `expo-cli` | Full Expo CLI command, such as `npx expo install` |
 | `eas-cli` | Full EAS CLI command, such as `eas build` |
-| `evals` | Expo area, package, or capability the failed task involves, such as `expo-router` or `eas build` |
+| `evals` | Expo package or command the failed task involves, else a capability phrase, such as `expo-router` or `eas build` |
 | `unknown` | Concise Expo product, package, feature, or other topic |
 
 In the final argument, say what helped and why, or provide the relevant context, expected behavior,
@@ -39,26 +39,32 @@ and what happened instead. Do not include secrets, source code, personal data, l
 ## Eval candidates: tasks that broke the model
 
 Expo turns hard real-world tasks into agent evals: anything Expo an agent can attempt — framework,
-EAS, tooling — qualifies, whether or not a skill was involved. The most valuable signal is a task an
-AI agent could not complete cleanly: repeated failed attempts, wrong or hallucinated APIs, a build
-or screen that never worked, or the user stepping in to fix it manually. When that happens — or the
-user says a model failed at an Expo task — confirm with the user, then submit from the project root
-(the CLI attaches the SDK and package versions, agent harness, and platform automatically) with
-`--category evals`, `--subject` naming the Expo area or capability the task involves, and this
-structure in the final argument:
+EAS, tooling — qualifies, whether or not a skill was involved. The signal worth sending is a task an
+AI agent could not complete cleanly despite real effort: several failed attempts, a build or screen
+that never worked, or the user stepping in to fix it manually. Never submit quick slips the agent
+corrected itself, more than one candidate per session, or a task already reported.
+
+When such a failure happens — or the user says a model failed at an Expo task — show the user the exact
+submission you intend to send and get approval; the Task field must describe the Expo-technical
+shape of the task, never the user's product or business context. Without a user to approve it
+(headless or CI runs), do not submit. Then run from the failing app's directory (the CLI attaches
+the SDK and package versions, agent harness, and platform automatically) with `--category evals`,
+`--subject` naming the Expo package or command involved (a capability phrase only when no single
+package fits), and this structure in the final argument:
 
 ```text
 Task: <what was asked, self-contained>.
 Expected: <observable success criteria>.
 Actual: <what the agent did instead>.
 Wrong approach: <the specific mistake, such as a wrong API, hallucinated prop, or bad pattern>.
-Evidence: <model name, number of attempts, and how it was eventually solved — or that it never was>.
+Evidence: <model name, attempts, how it was solved — or never was; omit what you cannot verify>.
 ```
 
 A good candidate is solvable (eventually done or clearly doable), verifiable (success is
 observable), and specific. Mention only environment details the CLI cannot see, such as other key
-packages or a freshly created app. Describe code; do not paste it. If the installed CLI rejects
-`--category evals`, resend with `--category unknown --subject "eval-candidate: <AREA>"`.
+packages or a freshly created app. Describe code; do not paste it. If the command fails with an
+error naming `evals` as an invalid category, resend once with `--category unknown` and the same
+subject prefixed `eval-candidate: `; on any other error, do not resend.
 
 ## Usage telemetry
 
@@ -78,4 +84,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-skill-feedback" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/expo-skill-feedback/SKILL.md
+++ b/plugins/expo/skills/expo-skill-feedback/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: expo-skill-feedback
-description: 'Submit feedback on an Expo skill—or Expo itself—and control bundled anonymous usage telemetry (off by default / opt-in). Submit feedback with: npx --yes submit-expo-feedback@latest "ACTIONABLE_FEEDBACK". Optionally add either or both: --category "CATEGORY" and --subject "SUBJECT". Replace the uppercase placeholders before running. Use when a skill was useful, confusing, broken, missing context, or worth improving; when Expo, Expo CLI, EAS CLI, docs, or MCP worked well or fell short; or when the user explicitly asks to enable or disable telemetry, check its status, or understand what it collects.'
+description: 'Submit feedback on an Expo skill—or Expo itself—and control bundled anonymous usage telemetry (off by default / opt-in). Submit feedback with: npx --yes submit-expo-feedback@latest "ACTIONABLE_FEEDBACK". Optionally add either or both: --category "CATEGORY" and --subject "SUBJECT". Replace the uppercase placeholders before running. Use when a skill was useful, confusing, broken, missing context, or worth improving; when Expo, Expo CLI, EAS CLI, docs, or MCP worked well or fell short; when an AI agent repeatedly failed, got stuck, or needed the user to take over an Expo task (report it as an eval candidate); or when the user explicitly asks to enable or disable telemetry, check its status, or understand what it collects.'
 ---
 
 # Expo Skill Feedback
@@ -30,10 +30,34 @@ When including them, choose the values that most precisely identify what the fee
 | `mcp` | Exact MCP tool name used |
 | `expo-cli` | Full Expo CLI command, such as `npx expo install` |
 | `eas-cli` | Full EAS CLI command, such as `eas build` |
+| `evals` | Expo area, package, or capability the failed task involves, such as `expo-router` or `eas build` |
 | `unknown` | Concise Expo product, package, feature, or other topic |
 
 In the final argument, say what helped and why, or provide the relevant context, expected behavior,
 and what happened instead. Do not include secrets, source code, personal data, long prompts, or stack traces.
+
+## Eval candidates: tasks that broke the model
+
+Expo turns hard real-world tasks into agent evals: anything Expo an agent can attempt — framework,
+EAS, tooling — qualifies, whether or not a skill was involved. The most valuable signal is a task an
+AI agent could not complete cleanly: repeated failed attempts, wrong or hallucinated APIs, a build
+or screen that never worked, or the user stepping in to fix it manually. When that happens — or the
+user says a model failed at an Expo task — confirm with the user, then submit with
+`--category evals`, `--subject` naming the Expo area or capability the task involves, and this
+structure in the final argument:
+
+```text
+Task: <what was asked, self-contained>.
+Environment: <SDK version, key packages, new or existing app>.
+Expected: <observable success criteria>.
+Actual: <what the agent did instead>.
+Wrong approach: <the specific mistake, such as a wrong API, hallucinated prop, or bad pattern>.
+Evidence: <model name, number of attempts, and how it was eventually solved — or that it never was>.
+```
+
+A good candidate is solvable (eventually done or clearly doable), verifiable (success is
+observable), and specific. Describe code; do not paste it. If the installed CLI rejects
+`--category evals`, resend with `--category unknown --subject "eval-candidate: <AREA>"`.
 
 ## Usage telemetry
 
@@ -53,3 +77,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-skill-feedback" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/expo-skill-feedback/SKILL.md
+++ b/plugins/expo/skills/expo-skill-feedback/SKILL.md
@@ -42,13 +42,13 @@ Expo turns hard real-world tasks into agent evals: anything Expo an agent can at
 EAS, tooling — qualifies, whether or not a skill was involved. The most valuable signal is a task an
 AI agent could not complete cleanly: repeated failed attempts, wrong or hallucinated APIs, a build
 or screen that never worked, or the user stepping in to fix it manually. When that happens — or the
-user says a model failed at an Expo task — confirm with the user, then submit with
+user says a model failed at an Expo task — confirm with the user, then submit from the project root
+(the CLI attaches the SDK and package versions, agent harness, and platform automatically) with
 `--category evals`, `--subject` naming the Expo area or capability the task involves, and this
 structure in the final argument:
 
 ```text
 Task: <what was asked, self-contained>.
-Environment: <SDK version, key packages, new or existing app>.
 Expected: <observable success criteria>.
 Actual: <what the agent did instead>.
 Wrong approach: <the specific mistake, such as a wrong API, hallucinated prop, or bad pattern>.
@@ -56,7 +56,8 @@ Evidence: <model name, number of attempts, and how it was eventually solved — 
 ```
 
 A good candidate is solvable (eventually done or clearly doable), verifiable (success is
-observable), and specific. Describe code; do not paste it. If the installed CLI rejects
+observable), and specific. Mention only environment details the CLI cannot see, such as other key
+packages or a freshly created app. Describe code; do not paste it. If the installed CLI rejects
 `--category evals`, resend with `--category unknown --subject "eval-candidate: <AREA>"`.
 
 ## Usage telemetry

--- a/plugins/expo/skills/expo-skill-feedback/agents/openai.yaml
+++ b/plugins/expo/skills/expo-skill-feedback/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Expo Skill Feedback"
-  short_description: "Help Expo improve with feedback and usage telemetry"
-  default_prompt: "Use $expo-skill-feedback to help Expo improve by submitting feedback or controlling Expo skills telemetry."
+  short_description: "Help Expo improve with feedback, eval candidates, and usage telemetry"
+  default_prompt: "Use $expo-skill-feedback to help Expo improve by submitting feedback, reporting an Expo task an AI agent failed at as an eval candidate, or controlling Expo skills telemetry."

--- a/plugins/expo/skills/expo-tailwind-setup/SKILL.md
+++ b/plugins/expo/skills/expo-tailwind-setup/SKILL.md
@@ -485,3 +485,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-tailwind-setup" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/expo-tailwind-setup/SKILL.md
+++ b/plugins/expo/skills/expo-tailwind-setup/SKILL.md
@@ -485,4 +485,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-tailwind-setup" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/expo-ui/SKILL.md
+++ b/plugins/expo/skills/expo-ui/SKILL.md
@@ -52,3 +52,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-ui" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/expo-ui/SKILL.md
+++ b/plugins/expo/skills/expo-ui/SKILL.md
@@ -52,4 +52,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-ui" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/expo-upgrade/SKILL.md
+++ b/plugins/expo/skills/expo-upgrade/SKILL.md
@@ -141,3 +141,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-upgrade" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/plugins/expo/skills/expo-upgrade/SKILL.md
+++ b/plugins/expo/skills/expo-upgrade/SKILL.md
@@ -141,4 +141,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-upgrade" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/expo-web-to-native/SKILL.md
+++ b/plugins/expo/skills/expo-web-to-native/SKILL.md
@@ -88,4 +88,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-web-to-native" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/expo-web-to-native/SKILL.md
+++ b/plugins/expo/skills/expo-web-to-native/SKILL.md
@@ -88,3 +88,4 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "expo-web-to-native" "<actionable feedback>"
 ```
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (`--category evals`).

--- a/scripts/check-skill-limits.ts
+++ b/scripts/check-skill-limits.ts
@@ -21,7 +21,7 @@ If you encounter errors, misleading or outdated information in this skill, repor
 npx --yes submit-expo-feedback@latest --category skills --subject "${skillName}" "<actionable feedback>"
 \`\`\`
 Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
-If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (\`--category evals\`).`;
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.`;
 }
 
 function findSkillFiles(dir: string): string[] {

--- a/scripts/check-skill-limits.ts
+++ b/scripts/check-skill-limits.ts
@@ -20,7 +20,8 @@ If you encounter errors, misleading or outdated information in this skill, repor
 \`\`\`bash
 npx --yes submit-expo-feedback@latest --category skills --subject "${skillName}" "<actionable feedback>"
 \`\`\`
-Only submit when you have something specific and actionable to report. Include as much relevant context as possible.`;
+Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, report it as an eval candidate via the expo-skill-feedback skill (\`--category evals\`).`;
 }
 
 function findSkillFiles(dir: string): string[] {


### PR DESCRIPTION
## Summary

Teaches agents to report Expo tasks that AI models fail at as **eval candidates**, riding the existing `submit-expo-feedback` pipe with a new `evals` category. These structured leads are the raw material for Harbor eval tasks — the hard, real-world, model-breaking tasks that are otherwise nearly impossible to source. Anything Expo an agent can attempt qualifies (framework, EAS, tooling), whether or not a skill was involved: if we can eval it, we can improve it.

## Changes

| Area | Change |
| --- | --- |
| `expo-skill-feedback` | New "Eval candidates" section with a structured lead template (Task / Environment / Expected / Actual / Wrong approach / Evidence), `evals` row in the category table (subject = Expo area or capability, e.g. `expo-router`, `eas build`), eval-candidate trigger added to the description, Codex `openai.yaml` updated |
| All skills | Canonical feedback footer gains one line routing agent failures to the eval-candidate flow (template in `check-skill-limits.ts`, propagated via `--fix-feedback`) |
| Manifests | Version bump `1.8.7` → `1.9.0` across Claude, Codex, and Cursor manifests |

## Notes

- The template fields map onto Harbor task anatomy: Task → `instruction.md`, Environment → `environment/`, Expected → rubric criteria, Wrong approach → "Must not …" negative criteria, Evidence → difficulty/solvability calibration.
- No backend change needed: `/v2/feedback/cli-send` passes categories through untouched to PostHog (`cli_feedback_submitted`) and Slack, so `evals` submissions are filterable server-side today.
- `--category evals` requires a `submit-expo-feedback` release (the category enum is client-side; companion change prepared for expo/expo). Until it ships, the skill documents the `--category unknown --subject "eval-candidate: <area>"` fallback.

## Validation

- `bun scripts/check-skill-limits.ts` ✓
- `bun scripts/check-plugin-version-bump.ts origin/main` ✓ (1.8.7 → 1.9.0, all three manifests together)
- `claude plugin validate .` and `claude plugin validate ./plugins/expo` ✓