### PR TITLE
[skills] drop evals category fallback now that the CLI supports it

### DIFF
--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/skills/expo-skill-feedback/SKILL.md
+++ b/plugins/expo/skills/expo-skill-feedback/SKILL.md
@@ -31,6 +31,7 @@ When including them, choose the values that most precisely identify what the fee
 | `expo-cli` | Full Expo CLI command, such as `npx expo install` |
 | `eas-cli` | Full EAS CLI command, such as `eas build` |
 | `evals` | Expo package or command the failed task involves, else a capability phrase, such as `expo-router` or `eas build` |
+| `simulator` | EAS Simulator feature or workflow involved |
 | `unknown` | Concise Expo product, package, feature, or other topic |
 
 In the final argument, say what helped and why, or provide the relevant context, expected behavior,

--- a/plugins/expo/skills/expo-skill-feedback/SKILL.md
+++ b/plugins/expo/skills/expo-skill-feedback/SKILL.md
@@ -62,9 +62,8 @@ Evidence: <model name, attempts, how it was solved — or never was; omit what y
 
 A good candidate is solvable (eventually done or clearly doable), verifiable (success is
 observable), and specific. Mention only environment details the CLI cannot see, such as other key
-packages or a freshly created app. Describe code; do not paste it. If the command fails with an
-error naming `evals` as an invalid category, resend once with `--category unknown` and the same
-subject prefixed `eval-candidate: `; on any other error, do not resend.
+packages or a freshly created app. Describe code; do not paste it. If the command fails, report the
+error to the user instead of resending.
 
 ## Usage telemetry
 


### PR DESCRIPTION
## Summary

Removes the interim fallback from the eval-candidate flow (`--category unknown --subject "eval-candidate: <area>"`), per @davidmokos's review comment on #126 — the `evals` category is now supported by the CLI itself (expo/expo#48511). A minimal error rule stays in its place ("if the command fails, report the error to the user instead of resending") so agents don't improvise resends on transient errors, which the usage simulation showed they otherwise do.

## Merge gate

**Do not merge until `submit-expo-feedback` ≥ 0.0.3 is published to the npm `latest` dist-tag** (currently `latest` = 0.0.2, which still rejects `--category evals`). The skills invoke `npx --yes submit-expo-feedback@latest`, so the release — not the expo/expo merge — is what makes the primary path work; until then this fallback is agents' only working path for eval submissions.

## Validation

- `bun scripts/check-skill-limits.ts` ✓
- `bun scripts/check-plugin-version-bump.ts origin/main` ✓ (1.9.0 → 1.9.1, all three manifests)
- `claude plugin validate ./plugins/expo` ✓

**Update:** also syncs the category table with the CLI's new contract from expo/expo#48520 (adds the `simulator` row; `evals` wording already matches). Both changes ride the same release gate.