### PR TITLE
[eas-observe] align skill with current docs and CLI

### DIFF
--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/skills/eas-observe/SKILL.md
+++ b/plugins/expo/skills/eas-observe/SKILL.md
@@ -7,7 +7,7 @@ license: MIT
 
 # EAS Observe
 
-> **EAS service - costs apply.** EAS Observe is an Expo Application Services product, currently in Open Beta. The first 10,000 monthly active users are free; higher usage requires contacting sales@expo.dev. Ingesting and querying production metrics counts against that allowance. Review https://expo.dev/pricing before enabling it in production.
+> **EAS service - costs apply.** EAS Observe is an Expo Application Services product. The free EAS plan allows up to 10,000 monthly active users, with a limited set of features; higher usage requires a paid subscription. For details, see https://expo.dev/pricing#plan-features.
 
 EAS Observe tracks startup, navigation, and custom-event performance from production Expo apps. It needs a development or production build — the native library is not in Expo Go.
 

--- a/plugins/expo/skills/eas-observe/SKILL.md
+++ b/plugins/expo/skills/eas-observe/SKILL.md
@@ -26,6 +26,7 @@ The four reference files in `./references/` cover what people typically need thi
 
 - Get started: https://docs.expo.dev/eas/observe/get-started/
 - Dashboard guide: https://docs.expo.dev/eas/observe/dashboard/
+- Querying with EAS CLI: https://docs.expo.dev/eas/observe/eas-cli/
 - Metrics reference: https://docs.expo.dev/eas/observe/reference/metrics/
 - Expo Router integration: https://docs.expo.dev/eas/observe/integrations/expo-router/
 - React Navigation integration: https://docs.expo.dev/eas/observe/integrations/react-navigation/
@@ -39,9 +40,9 @@ The four reference files in `./references/` cover what people typically need thi
 
 Verified against `eas-cli` 21.2.0 and `expo-observe` 57.0.9. Trust this skill's references over the docs on these points, but re-check with `--help` and the installed package before relying on them:
 
-- The docs list four CLI commands. `observe:routes` and `observe:session` also ship, undocumented.
-- The docs' EAS Update page shows `eas observe:metrics update_download --order desc`. There is no `--order` flag; it is `--sort <slowest|fastest|newest|oldest>`.
+- All six CLI commands are on the [Querying with EAS CLI](https://docs.expo.dev/eas/observe/eas-cli/) page. Older doc builds list only four and omit `observe:routes` and `observe:session`.
 - Navigation metric aliases are `nav_cold_ttr`, `nav_warm_ttr`, and `nav_tti`. There are no bare `cold_ttr` / `warm_ttr` aliases in the CLI.
+- Sorting uses `--sort <slowest|fastest|newest|oldest>`. There is no `--order` flag.
 - `ObserveErrorBoundary`, `Observe.reportError`, and `configure({ errorHandlingEnabled })` are exported but undocumented. Observe still has no crash reporting; use Sentry or BugSnag for that.
 
 ## Submitting Feedback

--- a/plugins/expo/skills/eas-observe/SKILL.md
+++ b/plugins/expo/skills/eas-observe/SKILL.md
@@ -38,7 +38,7 @@ The four reference files in `./references/` cover what people typically need thi
 
 ## Known gaps between the docs and the shipped code
 
-Verified against `eas-cli` 21.2.0 and `expo-observe` 57.0.9. Trust this skill's references over the docs on these points, but re-check with `--help` and the installed package before relying on them:
+Verified against `eas-cli` 21.8.0 and `expo-observe` 57.0.9. Trust this skill's references over the docs on these points, but re-check with `--help` and the installed package before relying on them:
 
 - All six CLI commands are on the [Querying with EAS CLI](https://docs.expo.dev/eas/observe/eas-cli/) page. Older doc builds list only four and omit `observe:routes` and `observe:session`.
 - Navigation metric aliases are `nav_cold_ttr`, `nav_warm_ttr`, and `nav_tti`. There are no bare `cold_ttr` / `warm_ttr` aliases in the CLI.

--- a/plugins/expo/skills/eas-observe/SKILL.md
+++ b/plugins/expo/skills/eas-observe/SKILL.md
@@ -1,25 +1,26 @@
 ---
 name: eas-observe
-description: EAS service (paid). Use for anything related to EAS Observe - adding `expo-observe` to an Expo project (AppMetricsRoot/ObserveRoot HOC, markInteractive, the useObserve hook, the Expo Router / React Navigation integrations for per-route metrics, and user-defined events via `Observe.logEvent`), querying via the EAS CLI (`eas observe:metrics-summary`, `observe:metrics`, `observe:routes`, `observe:events`, `observe:versions`), or interpreting the resulting metrics (cold/warm launch, TTR, TTI, navigation cold/warm TTR, update download, and the TTI frameRate params for triaging slow startups).
-version: 1.0.0
+description: EAS service (paid). Use for anything related to EAS Observe - adding `expo-observe` to an Expo project (AppMetricsRoot/ObserveRoot HOC, markInteractive and ObserveInteractiveMarker, the useObserve hook, the Expo Router / React Navigation integrations for per-route metrics, user-defined events via `Observe.logEvent`, error reporting via ObserveErrorBoundary and `Observe.reportError`, and runtime config such as sampleRate and dispatchInDebug), querying via the EAS CLI (`eas observe:metrics-summary`, `observe:metrics`, `observe:routes`, `observe:events`, `observe:session`, `observe:versions`), interpreting the resulting metrics (cold/warm launch, TTR, TTI, navigation cold/warm TTR, update download, and the TTI frameRate/device/network params for triaging slow startups), or shipping an Observe integration inside a third-party package.
+version: 1.1.0
 license: MIT
 ---
 
 # EAS Observe
 
-> **EAS service - costs apply.** EAS Observe is a paid Expo Application Services product with free-tier limits. Ingesting and querying production metrics counts against your plan's event/usage allowance. Review https://expo.dev/pricing before enabling it in production.
+> **EAS service - costs apply.** EAS Observe is an Expo Application Services product, currently in Open Beta. The first 10,000 monthly active users are free; higher usage requires contacting sales@expo.dev. Ingesting and querying production metrics counts against that allowance. Review https://expo.dev/pricing before enabling it in production.
 
-EAS Observe tracks startup, navigation, and custom-event performance from production Expo apps.
+EAS Observe tracks startup, navigation, and custom-event performance from production Expo apps. It needs a development or production build — the native library is not in Expo Go.
 
 > **Source of truth:** https://docs.expo.dev/eas/observe/ — always consult the canonical docs when API details matter, especially get-started, configuration, integrations, and the metrics reference. EAS Observe is evolving; this skill's references are written to stay accurate but may lag the docs.
 
 ## Which reference to read
 
-The three reference files in `./references/` cover the three things people typically need this skill for:
+The four reference files in `./references/` cover what people typically need this skill for:
 
-- **Adding EAS Observe to a project** → [`./references/setup.md`](./references/setup.md). Install, wrap the root layout (`AppMetricsRoot` on SDK 55, `ObserveRoot` on SDK 56+), call `markInteractive()` (global on SDK 55, via the `useObserve()` hook on SDK 56+), optional per-route navigation metrics through the Expo Router / React Navigation integrations, and user-defined events via `Observe.logEvent` (SDK 56+).
-- **Querying metrics from the terminal** → [`./references/queries.md`](./references/queries.md). The five `eas observe:*` commands — `metrics-summary`, `metrics`, `routes`, `events`, `versions` — with flags, table layouts, JSON shapes, and common workflows.
-- **Reading a dashboard or CLI output** → [`./references/metrics.md`](./references/metrics.md). Target thresholds per metric, what the TTI `frameRate.*` params mean, and diagnostic patterns for telling slow-but-smooth startup apart from main-thread contention or hard blocks.
+- **Adding EAS Observe to a project** → [`./references/setup.md`](./references/setup.md). Install, wrap the root layout (`AppMetricsRoot` on SDK 55, `ObserveRoot` on SDK 56+), mark the app interactive (global `markInteractive()` on SDK 55, the `useObserve()` hook or `<ObserveInteractiveMarker />` on SDK 56+), optional per-route navigation metrics through the Expo Router / React Navigation integrations, user-defined events via `Observe.logEvent` (SDK 56+), error reporting, and runtime configuration (sampling, dispatch, environments, custom endpoint).
+- **Querying metrics from the terminal** → [`./references/queries.md`](./references/queries.md). The six `eas observe:*` commands — `metrics-summary`, `metrics`, `routes`, `events`, `session`, `versions` — with flags, metric aliases, table layouts, JSON shapes, and common workflows.
+- **Reading a dashboard or CLI output** → [`./references/metrics.md`](./references/metrics.md). Target thresholds per metric, what the automatic TTI params mean (`frameRate.*`, `device.*`, `network.*`), and diagnostic patterns for telling slow-but-smooth startup apart from main-thread contention, hard blocks, or throttled devices.
+- **Shipping an Observe integration in a library** → [`./references/third-party.md`](./references/third-party.md). For package authors only (SDK 57+): optional peer dependency, config declaration merging, `Observe.registerIntegration()`, and event naming.
 
 ## Quick links to the docs
 
@@ -30,6 +31,18 @@ The three reference files in `./references/` cover the three things people typic
 - React Navigation integration: https://docs.expo.dev/eas/observe/integrations/react-navigation/
 - User-defined events: https://docs.expo.dev/eas/observe/events/
 - Configuration: https://docs.expo.dev/eas/observe/configuration/
+- Third-party integrations: https://docs.expo.dev/eas/observe/integrations/third-party/
+- EAS Update download performance: https://docs.expo.dev/eas/observe/eas-update/
+- Troubleshooting: https://docs.expo.dev/eas/observe/reference/troubleshooting/
+
+## Known gaps between the docs and the shipped code
+
+Verified against `eas-cli` 21.2.0 and `expo-observe` 57.0.9. Trust this skill's references over the docs on these points, but re-check with `--help` and the installed package before relying on them:
+
+- The docs list four CLI commands. `observe:routes` and `observe:session` also ship, undocumented.
+- The docs' EAS Update page shows `eas observe:metrics update_download --order desc`. There is no `--order` flag; it is `--sort <slowest|fastest|newest|oldest>`.
+- Navigation metric aliases are `nav_cold_ttr`, `nav_warm_ttr`, and `nav_tti`. There are no bare `cold_ttr` / `warm_ttr` aliases in the CLI.
+- `ObserveErrorBoundary`, `Observe.reportError`, and `configure({ errorHandlingEnabled })` are exported but undocumented. Observe still has no crash reporting; use Sentry or BugSnag for that.
 
 ## Submitting Feedback
 If you encounter errors, misleading or outdated information in this skill, report it so Expo can improve:

--- a/plugins/expo/skills/eas-observe/agents/openai.yaml
+++ b/plugins/expo/skills/eas-observe/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "EAS Observe"
   short_description: "Paid EAS service. Set up expo-observe app metrics and query launch, route, event, and version performance with the EAS CLI"
-  default_prompt: "Use $eas-observe to add expo-observe instrumentation (AppMetricsRoot/ObserveRoot, useObserve, the router integrations), query metrics with eas observe:* commands, and interpret cold/warm launch, TTR, and TTI results."
+  default_prompt: "Use $eas-observe to add expo-observe instrumentation (AppMetricsRoot/ObserveRoot, useObserve, ObserveInteractiveMarker, the router integrations, error reporting), query metrics with eas observe:* commands, and interpret cold/warm launch, TTR, and TTI results."

--- a/plugins/expo/skills/eas-observe/references/metrics.md
+++ b/plugins/expo/skills/eas-observe/references/metrics.md
@@ -51,6 +51,35 @@ Every TTI event carries automatic params in three groups: frame rate, device sta
 |---|---|---|
 | `expo.network.connected` | boolean | If TTI degrades only when `true`, startup is network-bound. If it degrades when `false`, the app does too much before showing cached content. |
 | `expo.network.type` | `wifi` \| `cellular` \| `ethernet` \| `none` \| `other` \| `unknown` | Compare cellular against Wi-Fi. A large gap points to network-bound startup work. VPN traffic reports the underlying transport. The value set is identical on both platforms, so dashboards need no per-platform branching. |
+| `expo.network.isExpensive` | boolean | Both platforms. The OS considers the connection metered (cellular, hotspot). Present only when a network exists. |
+| `expo.network.isConstrained` | boolean | **iOS only.** Low Data Mode is on for this path, so the system defers background transfers. |
+| `expo.network.dataSaverEnabled` | boolean | **Android only.** Data Saver is on. It is the nearest equivalent of Low Data Mode, but process-wide rather than per-path, hence the separate key. |
+
+### Network requests — was the network the cause?
+
+TTI events summarize the HTTP requests made during launch, from the end of the native launch to the `markInteractive()` call. Traffic is observed automatically — `URLSession` on iOS, `OkHttpClient` on Android, which covers `fetch` — and Observe's own uploads are excluded. All of these are omitted when the window held no requests.
+
+| Param | Unit | What it indicates |
+|---|---|---|
+| `expo.network.requests.count` | count | Requests started in the window. |
+| `expo.network.requests.failed` | count | Errored or non-2xx. The signal for a launch stalled on a request that never arrived. |
+| `expo.network.requests.bytesReceived` / `.bytesSent` | bytes | On-the-wire totals for the window. |
+| `expo.network.requests.totalDuration` | seconds | Sum of every request duration, failures included. Exceeds wall-clock when requests overlap; one timeout contributes the client's full timeout interval. |
+| `expo.network.requests.throughputBytesPerSecond` | bytes/sec | Received bytes over the time bytes were actually moving (union of transfer windows, measured from each first byte). Excludes DNS, connect, server think time, cache hits, and failures. Omitted when nothing was received. |
+| `expo.network.requests.slowest.duration` | seconds | The single longest **completed** request. Requests that never produced a response are excluded, since a timeout measures the client's own setting. |
+| `expo.network.requests.slowest.host` | string | Host of that request. |
+| `expo.network.requests.slowest.statusCode` | number | Explains an empty response: `bytesReceived` of 0 is routine on a 304, a problem on a 200. |
+| `expo.network.requests.slowest.timeToFirstByte` | seconds | Includes server processing, so treat it as a proxy for network quality, not a measurement of it. |
+| `expo.network.requests.slowest.bytesReceived` | bytes | Separates "slow because it moved a lot of data" from "slow while idle". |
+
+**Diagnostic patterns:**
+
+- **`slowest.duration` mostly `timeToFirstByte`** → the server was slow to answer. Optimize the endpoint, or stop blocking startup on it.
+- **Small `timeToFirstByte` + large `bytesReceived`** → the transfer itself was slow. Shrink the payload or defer it.
+- **High `failed` + high `totalDuration`** → the launch burned time on requests that never arrived. Add timeouts and render cached content first.
+- **Low `throughputBytesPerSecond` on `wifi`** → suspect the population, not the code; cross-check `isExpensive` and `isConstrained` / `dataSaverEnabled`.
+
+> The summary is bounded by an in-memory ring buffer of the 200 most recent requests. A launch that makes more undercounts, so read these as a sample of a very busy window.
 
 ### Custom params
 

--- a/plugins/expo/skills/eas-observe/references/metrics.md
+++ b/plugins/expo/skills/eas-observe/references/metrics.md
@@ -61,11 +61,11 @@ TTI events summarize the HTTP requests made during launch, from the end of the n
 
 | Param | Unit | What it indicates |
 |---|---|---|
-| `expo.network.requests.count` | count | Requests started in the window. |
-| `expo.network.requests.failed` | count | Errored or non-2xx. The signal for a launch stalled on a request that never arrived. |
+| `expo.network.requests.count` | count | Requests that finished in the window. A request still in flight when the app became interactive is not counted anywhere in this table. |
+| `expo.network.requests.failed` | count | Errored, returned 4xx/5xx, never got a response, or broke partway through the body. Redirects are not failures. |
 | `expo.network.requests.bytesReceived` / `.bytesSent` | bytes | On-the-wire totals for the window. |
 | `expo.network.requests.totalDuration` | seconds | Sum of every request duration, failures included. Exceeds wall-clock when requests overlap; one timeout contributes the client's full timeout interval. |
-| `expo.network.requests.throughputBytesPerSecond` | bytes/sec | Received bytes over the time bytes were actually moving (union of transfer windows, measured from each first byte). Excludes DNS, connect, server think time, cache hits, and failures. Omitted when nothing was received. |
+| `expo.network.requests.throughputBytesPerSecond` | bytes/sec | Received bytes over the time bytes were actually moving (union of transfer windows, measured from each first byte). Excludes DNS, connect, server think time, cache hits, and failures. Requests the OS did not clearly identify as network loads are excluded too. Omitted when nothing was received. |
 | `expo.network.requests.slowest.duration` | seconds | The single longest **completed** request. Requests that never produced a response are excluded, since a timeout measures the client's own setting. |
 | `expo.network.requests.slowest.host` | string | Host of that request. |
 | `expo.network.requests.slowest.statusCode` | number | Explains an empty response: `bytesReceived` of 0 is routine on a 304, a problem on a 200. |

--- a/plugins/expo/skills/eas-observe/references/metrics.md
+++ b/plugins/expo/skills/eas-observe/references/metrics.md
@@ -4,7 +4,7 @@ Quick reference for reading EAS Observe dashboards and CLI output.
 
 > Source: https://docs.expo.dev/eas/observe/reference/metrics/ — this is the canonical reference for metrics. Consult this page for the latest guidance, full prose definitions, optimization tips, and rationale.
 
-All durations are in seconds. Data is retained for 90 days. All durations are in seconds. By default, every installation dispatches all of its events. Apps with high volumes can opt into per-installation sampling via configure({ sampleRate }). See [Sampling](https://docs.expo.dev/eas/observe/configuration/#sampling).
+All durations are in seconds. Metric data is retained for a minimum of 60 days. By default, every installation dispatches all of its events; high-volume apps can sample per installation with `configure({ sampleRate })` — see [Sampling](https://docs.expo.dev/eas/observe/configuration/#sampling).
 
 ## Target thresholds
 
@@ -18,9 +18,11 @@ All durations are in seconds. Data is retained for 90 days. All durations are in
 
 Both TTR and TTI are measured *from native launch* through the React render, so the cold-launch portion counts against them.
 
-## Interpreting TTI events (frameRate params)
+## Interpreting TTI events (automatic params)
 
-Every TTI event carries three frame-rate params. The pattern of high/low values across them tells you *what kind* of slowness you're seeing.
+Every TTI event carries automatic params in three groups: frame rate, device state, and network state. Read the frame-rate group to classify *what kind* of slowness you're seeing, then read the device and network groups to decide whether the cause is the code or the conditions.
+
+### Frame rate — what kind of slowness
 
 | Param | Definition | What it indicates |
 |---|---|---|
@@ -33,6 +35,26 @@ Every TTI event carries three frame-rate params. The pattern of high/low values 
 - **High TTI + low totalDelay** → slow but smooth. The launch sequence itself is long. Optimize bundle size, data-fetch waterfalls, initialization chains.
 - **High TTI + high totalDelay + many slowFrames** → main-thread contention. Offload work, simplify the initial render tree.
 - **High TTI + high totalDelay + any frozenFrames** → something is blocking hard. Look for synchronous I/O, large JSON parsing, or blocking network calls.
+
+### Device state — is the regression environmental?
+
+| Param | Type | What it indicates |
+|---|---|---|
+| `expo.device.lowPowerMode` | boolean | OS power saver was active (Low Power Mode on iOS, Battery Saver on Android). It throttles CPU, GPU, and background work. A regression that disappears when you filter this out is environmental, not a code change. |
+| `expo.device.thermalState` | `nominal` \| `fair` \| `serious` \| `critical` \| `unknown` | Sustained `serious`/`critical` means the OS is throttling. Startup slows independently of any app change. |
+| `expo.device.batteryLevel` | number, 0–1 | Fractional charge at TTI. Rules out throttling on devices that manage performance aggressively at low charge. Omitted when the OS reports no value. |
+| `expo.device.batteryCharging` | boolean | Charging raises sustained CPU ceilings on iOS and some Android OEMs. Non-charging samples are the more conservative population. |
+
+### Network state — is startup network-bound?
+
+| Param | Type | What it indicates |
+|---|---|---|
+| `expo.network.connected` | boolean | If TTI degrades only when `true`, startup is network-bound. If it degrades when `false`, the app does too much before showing cached content. |
+| `expo.network.type` | `wifi` \| `cellular` \| `ethernet` \| `none` \| `other` \| `unknown` | Compare cellular against Wi-Fi. A large gap points to network-bound startup work. VPN traffic reports the underlying transport. The value set is identical on both platforms, so dashboards need no per-platform branching. |
+
+### Custom params
+
+You can attach your own params to the TTI event, and override the route name it is tagged with. See [`./setup.md`](./setup.md) for the call syntax.
 
 ## Dispatch caveats
 

--- a/plugins/expo/skills/eas-observe/references/queries.md
+++ b/plugins/expo/skills/eas-observe/references/queries.md
@@ -1,18 +1,21 @@
 # EAS Observe CLI
 
-EAS Observe collects app performance telemetry and custom events from Expo apps and exposes them through five EAS CLI commands. Pass the `--help` flag to any command for the latest API.
+EAS Observe collects app performance telemetry and custom events from Expo apps and exposes them through six EAS CLI commands. Pass the `--help` flag to any command for the latest API — the flags below were verified against `eas-cli` 21.2.0.
 
 ## Commands Overview
 
 | Command | Purpose |
 |---------|---------|
-| `eas observe:metrics-summary` | Per-version statistical aggregates for app-startup performance metrics (median, p90, etc.) |
-| `eas observe:metrics` | Individual performance metric samples ordered by value or timestamp (paginated) |
-| `eas observe:routes` | Per-route statistical aggregates for navigation metrics (Cold TTR, Warm TTR, Nav TTI) |
+| `eas observe:metrics-summary` | Per-version statistical aggregates for startup and navigation metrics (median, p90, etc.) |
+| `eas observe:metrics` | Individual metric samples ordered by value or timestamp (paginated) |
+| `eas observe:routes` | Per-route statistical aggregates for navigation metrics (Nav Cold TTR, Nav Warm TTR, Nav TTI) |
 | `eas observe:events` | Custom events emitted by the app via `logEvent` — name summary, all events, or filtered by event name (paginated) |
+| `eas observe:session` | Full timeline of metric and log events for one session |
 | `eas observe:versions` | App version hierarchy with build numbers, OTA update IDs, and event counts |
 
-All five commands share these common flags:
+> The published docs list only `metrics-summary`, `metrics`, `events`, and `versions`. `routes` and `session` ship in the CLI but are not documented yet; run `--help` to confirm them on your installed version.
+
+All six commands share these common flags:
 
 - `--platform ios` or `--platform android` — filter by platform (default: both)
 - `--start <ISO date>` and `--end <ISO date>` — explicit time range
@@ -27,8 +30,6 @@ Default time range is the last 60 days when none of `--days`, `--start`, `--end`
 
 ### App-startup metrics
 
-Used by `observe:metrics-summary` and `observe:metrics`.
-
 | Alias | Full name | Display |
 |-------|-----------|---------|
 | `tti` | `expo.app_startup.tti` | Startup TTI (time to interactive) |
@@ -40,13 +41,15 @@ Used by `observe:metrics-summary` and `observe:metrics`.
 
 ### Navigation metrics
 
-Used by `observe:routes`. Measured per route name.
+Emitted only when a navigation integration is enabled (SDK 56+). Measured per route name.
 
 | Alias | Full name | Display |
 |-------|-----------|---------|
-| `cold_ttr` | `expo.navigation.cold_ttr` | Nav Cold TTR |
-| `warm_ttr` | `expo.navigation.warm_ttr` | Nav Warm TTR |
+| `nav_cold_ttr` | `expo.navigation.cold_ttr` | Nav Cold TTR |
+| `nav_warm_ttr` | `expo.navigation.warm_ttr` | Nav Warm TTR |
 | `nav_tti` | `expo.navigation.tti` | Nav TTI |
+
+**Which command takes which alias.** `observe:metrics` (positional argument) and `observe:metrics-summary --metric` accept **all nine** aliases — startup and navigation. `observe:routes --metric` accepts only the three navigation aliases. Use the `nav_` prefix everywhere; there are no bare `cold_ttr` / `warm_ttr` aliases.
 
 ## `eas observe:metrics-summary`
 
@@ -61,6 +64,9 @@ eas observe:metrics-summary --metric tti
 
 # Multiple metrics — each renders as its own table
 eas observe:metrics-summary --metric tti --metric cold_launch
+
+# Navigation metrics aggregate per version here, per route in observe:routes
+eas observe:metrics-summary --metric nav_tti
 
 # Choose which statistics to display
 eas observe:metrics-summary --metric tti --stat median --stat p90 --stat eventCount
@@ -111,6 +117,9 @@ eas observe:metrics
 # Specify metric as positional arg
 eas observe:metrics tti
 
+# Navigation metrics work here too
+eas observe:metrics nav_tti --sort slowest
+
 # Filter by version or update, sort by slowest
 eas observe:metrics tti --app-version 1.2.0 --sort slowest --limit 20
 
@@ -143,7 +152,7 @@ eas observe:routes
 eas observe:routes --metric nav_tti --days 7 --platform ios
 
 # Multiple metrics and stats
-eas observe:routes --metric cold_ttr --metric warm_ttr --stat median --stat p90 --stat count
+eas observe:routes --metric nav_cold_ttr --metric nav_warm_ttr --stat median --stat p90 --stat count
 
 # Filter to a single build
 eas observe:routes --app-version 1.2.0 --build-number 42
@@ -156,7 +165,7 @@ eas observe:routes --after <cursor>
 ```
 
 **Routes-specific flags:**
-- `--metric <cold_ttr|warm_ttr|nav_tti>` — navigation metric(s) to display, can be repeated. Defaults to all three.
+- `--metric <nav_cold_ttr|nav_warm_ttr|nav_tti>` — navigation metric(s) to display, can be repeated. Defaults to all three.
 - `--stat <median|p90|count>` — statistic(s) per metric. Aliases: `med` → `median`, `event_count` / `eventCount` → `count`.
 - `--limit <N>` — routes per page (default **50**, max **200**, different from `metrics`/`events` which default to 10).
 - `--after <cursor>` — pagination cursor from the previous run.
@@ -222,7 +231,7 @@ eas observe:events login_failed --after <cursor>
 
 **Events-specific flags:**
 - `--all-events` — when no event name argument is given, list all events instead of the name summary. Cannot be combined with an event name argument.
-- `--session-id <id>` — filter to events from a single session (events-only)
+- `--session-id <id>` — filter to events from a single session (events-only). With no event name argument, this lists the session's events instead of the event-name summary. For the full timeline — metrics as well as log events — use `observe:session`.
 - `--app-version <version>` — filter by app version string
 - `--update-id <id>` — filter by EAS update ID
 - `--limit <N>` — events per page (default 10, max 100)
@@ -267,6 +276,28 @@ eas observe:events login_failed --after <cursor>
 
 The name-summary mode returns `{ "names": [{ "eventName": "...", "count": 123 }], "isTruncated": false }`.
 
+## `eas observe:session`
+
+Shows the full timeline of metric and log events for a single session — the CLI equivalent of the dashboard's session view. Use it after `observe:metrics` surfaces a slow sample: take that sample's `sessionId` (present in `--json` output) and replay everything that session recorded.
+
+```bash
+# Interactive: pick a metric, then pick a session from the candidate list
+eas observe:session
+
+# Inspect a known session
+eas observe:session <session-id>
+
+# Pick a session from the slowest TTI events in the last 7 days
+eas observe:session --event-name tti --sort slowest --days 7
+```
+
+**Session-specific flags:**
+- `[SESSIONID]` — positional. Omit it in interactive mode to choose from a list.
+- `--event-name <name>` — metric or log event used to build the candidate session list (for example `tti`, `cold_launch`, `login_pressed`). Prompts when omitted in interactive mode.
+- `--sort <slowest|fastest|newest|oldest>` — orders the candidate events. Prompts when omitted in interactive mode.
+
+This command has no `--platform`, `--limit`, or `--after` flag. It takes the shared time-range, `--project-id`, `--json`, and `--non-interactive` flags.
+
 ## `eas observe:versions`
 
 Shows app version hierarchy with build numbers, OTA update IDs, and event counts per version.
@@ -303,6 +334,12 @@ eas observe:metrics-summary --metric update_download --days 7
 **"Which screens are slowest to navigate to?"**
 ```bash
 eas observe:routes --metric nav_tti --stat median --stat p90 --days 7
+```
+
+**"What happened during that one slow session?"**
+```bash
+eas observe:metrics tti --sort slowest --days 7 --json   # read sessionId from a sample
+eas observe:session <session-id>
 ```
 
 **"How does navigation perform on just the routes I care about?"**

--- a/plugins/expo/skills/eas-observe/references/queries.md
+++ b/plugins/expo/skills/eas-observe/references/queries.md
@@ -2,6 +2,8 @@
 
 EAS Observe collects app performance telemetry and custom events from Expo apps and exposes them through six EAS CLI commands. Pass the `--help` flag to any command for the latest API — the flags below were verified against `eas-cli` 21.2.0.
 
+> Source: https://docs.expo.dev/eas/observe/eas-cli/ — the canonical CLI page. This reference adds table layouts, JSON output shapes, and pagination details that the docs page does not cover.
+
 ## Commands Overview
 
 | Command | Purpose |
@@ -13,7 +15,7 @@ EAS Observe collects app performance telemetry and custom events from Expo apps 
 | `eas observe:session` | Full timeline of metric and log events for one session |
 | `eas observe:versions` | App version hierarchy with build numbers, OTA update IDs, and event counts |
 
-> The published docs list only `metrics-summary`, `metrics`, `events`, and `versions`. `routes` and `session` ship in the CLI but are not documented yet; run `--help` to confirm them on your installed version.
+> Older published docs list only `metrics-summary`, `metrics`, `events`, and `versions`. All six are on the [Querying with EAS CLI](https://docs.expo.dev/eas/observe/eas-cli/) page; run `--help` to confirm them on your installed version.
 
 All six commands share these common flags:
 

--- a/plugins/expo/skills/eas-observe/references/queries.md
+++ b/plugins/expo/skills/eas-observe/references/queries.md
@@ -1,6 +1,6 @@
 # EAS Observe CLI
 
-EAS Observe collects app performance telemetry and custom events from Expo apps and exposes them through six EAS CLI commands. Pass the `--help` flag to any command for the latest API — the flags below were verified against `eas-cli` 21.2.0.
+EAS Observe collects app performance telemetry and custom events from Expo apps and exposes them through six EAS CLI commands. Pass the `--help` flag to any command for the latest API — the flags below were verified against `eas-cli` 21.8.0.
 
 > Source: https://docs.expo.dev/eas/observe/eas-cli/ — the canonical CLI page. This reference adds table layouts, JSON output shapes, and pagination details that the docs page does not cover.
 
@@ -17,16 +17,19 @@ EAS Observe collects app performance telemetry and custom events from Expo apps 
 
 > Older published docs list only `metrics-summary`, `metrics`, `events`, and `versions`. All six are on the [Querying with EAS CLI](https://docs.expo.dev/eas/observe/eas-cli/) page; run `--help` to confirm them on your installed version.
 
-All six commands share these common flags:
+All six commands share these flags:
 
-- `--platform ios` or `--platform android` — filter by platform (default: both)
 - `--start <ISO date>` and `--end <ISO date>` — explicit time range
-- `--days <N>` — show data from the last N days (mutually exclusive with `--start`/`--end`)
+- `--days <N>` — show data from the last N days (mutually exclusive with `--start`/`--end`, minimum 1)
 - `--project-id <id>` — run against a specific project without needing a project directory. When passed, the command will not try to create a new EAS project where one is unneeded.
 - `--json` — machine-readable output (implies `--non-interactive`)
 - `--non-interactive` — fail instead of prompting
 
+`--platform ios` / `--platform android` (default: both) is on every command **except `observe:session`**, which is scoped to one session already.
+
 Default time range is the last 60 days when none of `--days`, `--start`, `--end` is given.
+
+**Plan gating.** Observe is a paid feature, and the server rejects queries the account's plan does not include (`EAS_OBSERVE_PLAN_UPGRADE_REQUIRED` or `EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER`). The CLI surfaces the server's upgrade message, which links to the account's billing page. Session timelines in particular are checked before the interactive picker runs. A plan-gate failure is not a bug in the command or its flags.
 
 ## Supported Metrics
 
@@ -53,6 +56,8 @@ Emitted only when a navigation integration is enabled (SDK 56+). Measured per ro
 
 **Which command takes which alias.** `observe:metrics` (positional argument) and `observe:metrics-summary --metric` accept **all nine** aliases — startup and navigation. `observe:routes --metric` accepts only the three navigation aliases. Use the `nav_` prefix everywhere; there are no bare `cold_ttr` / `warm_ttr` aliases.
 
+`observe:metrics` also accepts a full metric name in place of an alias, for example `eas observe:metrics expo.app_startup.tti`. `observe:routes` accepts full navigation names the same way. The `--metric` flags on `metrics-summary` and `routes` are strict oclif options, so they take aliases only.
+
 ## `eas observe:metrics-summary`
 
 Shows per-version statistical aggregates for one or more metrics, with separate tables per platform.
@@ -77,9 +82,11 @@ eas observe:metrics-summary --metric tti --stat median --stat p90 --stat eventCo
 eas observe:metrics-summary --metric tti --days 14 --platform ios
 ```
 
-**Stat flags:** `min`, `max`, `median` (alias `med`), `average` (alias `avg`), `p80`, `p90`, `p99`, `eventCount` (alias `count`).
+**Stat flags:** exactly `min`, `median`, `max`, `average`, `p80`, `p90`, `p99`, `eventCount`. This command takes **no aliases** — `med`, `avg`, and `count` are rejected here (they work only on `observe:routes`).
 
-**Default stats:** `median` + `eventCount` in the table; all stats in JSON.
+**Default stats:** `median` + `eventCount` in the table; all eight in JSON.
+
+This command has no `--limit`, `--after`, `--app-version`, or `--update-id`. It always aggregates every version in the time range.
 
 **Table layout:**
 - One table per metric (with merged value + event count cells, e.g. `0.45s (150)`)
@@ -294,11 +301,26 @@ eas observe:session --event-name tti --sort slowest --days 7
 ```
 
 **Session-specific flags:**
-- `[SESSIONID]` — positional. Omit it in interactive mode to choose from a list.
+- `[SESSIONID]` — positional. Omit it in interactive mode to choose from a list. **Required in non-interactive mode**, including under `--json`.
 - `--event-name <name>` — metric or log event used to build the candidate session list (for example `tti`, `cold_launch`, `login_pressed`). Prompts when omitted in interactive mode.
-- `--sort <slowest|fastest|newest|oldest>` — orders the candidate events. Prompts when omitted in interactive mode.
+- `--sort <slowest|fastest|newest|oldest>` — orders the candidate events. Prompts when omitted in interactive mode. No default, unlike `observe:metrics`.
+
+**The picker flags and the session ID are mutually exclusive.** `--event-name`, `--sort`, `--days`, `--start`, and `--end` describe how to *find* a session, so passing any of them together with a session ID throws. Query a known session with the ID alone.
 
 This command has no `--platform`, `--limit`, or `--after` flag. It takes the shared time-range, `--project-id`, `--json`, and `--non-interactive` flags.
+
+**JSON output shape:**
+```json
+{
+  "sessionId": "...",
+  "metadata": { "...": "..." },
+  "entries": [{ "...": "..." }],
+  "hasMoreMetricEvents": false,
+  "hasMoreLogEvents": false
+}
+```
+
+`entries` interleaves metric and log events for the session. The two `hasMore*` flags report truncation per event kind; there is no cursor to page with.
 
 ## `eas observe:versions`
 

--- a/plugins/expo/skills/eas-observe/references/setup.md
+++ b/plugins/expo/skills/eas-observe/references/setup.md
@@ -449,6 +449,8 @@ The value is normalized before it is sent: an `Error` contributes `name`, `messa
 | `errorHandlingEnabled` | boolean | `true` | Record unhandled JS errors as `exception` events. |
 | `integrations` | object | `undefined` | Opt in to `expo-router`, `react-navigation`, or a third-party integration. |
 
+**Network request monitoring is automatic and has no off switch.** `expo-observe` observes `URLSession` traffic on iOS and `OkHttpClient` traffic on Android from launch, and attaches a rollup of the launch window to the TTI event — including the **host** of the slowest request (see [`./metrics.md`](./metrics.md)). Observe's own uploads are excluded. No `configure()` option disables it as of `expo-observe` 57.0.9, so treat request hosts as data that leaves the device.
+
 **Sampling** is deterministic per installation: an installation is permanently in-sample or out-of-sample for a given rate, so the slice is stable across launches rather than a random subset of sessions. Out-of-sample installations drop pending metrics instead of accumulating them, so lowering the rate later does not retroactively send earlier sessions. Values outside `[0, 1]` are clamped. Sampling depends on `dispatchingEnabled`.
 
 **Manual flush.** Events dispatch automatically when the app backgrounds — on Android through a background worker once connectivity returns, on iOS when the app resigns active or is about to terminate. Call `await Observe.dispatchEvents()` to flush early, which is mainly useful while testing.

--- a/plugins/expo/skills/eas-observe/references/setup.md
+++ b/plugins/expo/skills/eas-observe/references/setup.md
@@ -23,6 +23,7 @@ Before installing, confirm all of the following:
 1. **An Expo account.** Sign up at [expo.dev/signup](https://expo.dev/signup) if needed.
 2. **Expo SDK 55 or later.** Run `npx expo-doctor` to check, and `npx expo install --fix` to update dependencies. SDK 56+ unlocks the newer `ObserveRoot` / `useObserve` API.
 3. **An EAS project.** The app must have `extra.eas.projectId` set in its app config. If not, run `eas init` to create one.
+4. **A development build or a production build.** `expo-observe` is a native library, so it does **not** work in Expo Go. Testing the integration requires a [development build](https://docs.expo.dev/develop/development-builds/introduction/).
 
 ## Step 1 — Install the library
 
@@ -162,6 +163,40 @@ export default ObserveRoot.wrap(RootLayout);
 
 `markInteractive()` is safe to call repeatedly — only the **first** call per session is recorded. If the app has more than one entry screen (onboarding, login, deep-link targets), call `markInteractive()` on **each one**. Otherwise TTI will be missing for sessions that open via a deep link to a screen without the call.
 
+### Custom params and route name
+
+`markInteractive()` accepts an options object. Use `params` to slice TTI by an app-specific dimension (cohort, tenant, feature-flag variant, cache hit). Use `routeName` to override the route the event is tagged with — useful when the logical screen name differs from the router path, when the route is dynamic, or when the app does not use Expo Router. Param values may be strings, numbers, booleans, or any JSON-serializable value.
+
+```tsx
+// SDK 56+: const { markInteractive } = useObserve();
+// SDK 55:  AppMetrics.markInteractive({ ... })
+markInteractive({
+  routeName: '/feed',
+  params: { tenant: 'acme', cohort: 'beta', cacheHit: true },
+});
+```
+
+### Declarative alternative: `<ObserveInteractiveMarker />` (SDK 56+)
+
+Instead of calling `markInteractive()` from an effect, render the marker component at the point the screen becomes interactive. It renders nothing and calls `markInteractive()` once on mount.
+
+```tsx
+import { ObserveInteractiveMarker } from 'expo-observe';
+
+function Feed({ items }) {
+  if (!items) return <Spinner />;
+
+  return (
+    <>
+      <FeedList items={items} />
+      <ObserveInteractiveMarker params={{ cacheHit: true }} />
+    </>
+  );
+}
+```
+
+The marker fires **once**, on mount, so its `params` are read from the first render. Changing them later has no effect and logs a development warning. When the params are only known later, call `useObserve().markInteractive(...)` imperatively instead.
+
 ## Step 4 — Build the app
 
 Metrics are collected from real builds, not from `expo start`:
@@ -180,7 +215,7 @@ To query metrics from the terminal with the EAS CLI, see [`./queries.md`](./quer
 
 ## Optional — per-route navigation metrics (SDK 56+)
 
-By default `expo-observe` records app-wide startup metrics only. To additionally get **per-route / per-screen** navigation metrics (`cold_ttr`, `warm_ttr`, and a per-navigation `tti`, each tagged with the route/screen), enable one of the navigation integrations. These require **SDK 56 or later**; on earlier SDKs they are silent no-ops. Query the resulting data with `eas observe:routes` (see [`./queries.md`](./queries.md)).
+By default `expo-observe` records app-wide startup metrics only. To additionally get **per-route / per-screen** navigation metrics (`cold_ttr`, `warm_ttr`, and a per-navigation `tti`, each tagged with the route/screen), enable one of the navigation integrations. These require **SDK 56 or later**; on earlier SDKs they are silent no-ops. Query the resulting data with `eas observe:routes`, or with `observe:metrics` / `observe:metrics-summary` under the CLI aliases `nav_cold_ttr`, `nav_warm_ttr`, and `nav_tti` (see [`./queries.md`](./queries.md)).
 
 Pick the integration that matches the app's router:
 
@@ -216,6 +251,8 @@ Docs: https://docs.expo.dev/eas/observe/integrations/expo-router/
 
 Events are tagged with the route **pattern** (e.g. `/(tabs)/sessions/[sessionId]`) so the dashboard buckets distinct param values together; the resolved `url` and `routeParams` are also included. Requires `expo-router` installed at runtime, or the integration no-ops.
 
+`router.prefetch()` does not count as a user navigation and never seeds a `cold_ttr` or `warm_ttr` measurement. The next user-driven navigation to a prefetched route emits `warm_ttr`, because the screen already rendered.
+
 ### React Navigation
 
 Docs: https://docs.expo.dev/eas/observe/integrations/react-navigation/
@@ -233,7 +270,9 @@ Requires `@react-navigation/native` 7.0.0 or later. Same `useObserve()` screen u
    });
    ```
 
-2. Replace the top-level `<NavigationContainer>` with `<ObserveNavigationContainer>` — a drop-in replacement that accepts the same props and forwards the same ref. If you pass a `linking` config it is used to resolve a human-readable screen path; otherwise the metric falls back to `route.name`.
+2. Connect the integration to the navigation tree. Which component you use depends on whether the app uses React Navigation's dynamic or static configuration. Both record the same per-screen metrics.
+
+   **Dynamic configuration** — replace the top-level `<NavigationContainer>` with `<ObserveNavigationContainer>`. It is a drop-in replacement that accepts the same props and forwards the same ref. If you pass a `linking` config it is used to resolve a human-readable screen path; otherwise the metric falls back to `route.name`.
 
    ```tsx
    import { ObserveNavigationContainer } from 'expo-observe/integrations/react-navigation';
@@ -243,7 +282,64 @@ Requires `@react-navigation/native` 7.0.0 or later. Same `useObserve()` screen u
    }
    ```
 
+   **Static configuration** — `createStaticNavigation()` renders the container for you, so there is nothing to replace. Create the navigation ref yourself, pass it to both `<Navigation>` and `<ObserveNavigationProvider>`, and the provider records the same timings by listening through that ref.
+
+   ```tsx
+   import { createStaticNavigation, useNavigationContainerRef } from '@react-navigation/native';
+   import { ObserveNavigationProvider } from 'expo-observe/integrations/react-navigation';
+
+   const Navigation = createStaticNavigation(RootStack);
+
+   export default function App() {
+     const navigationRef = useNavigationContainerRef();
+
+     return (
+       <ObserveNavigationProvider navigationRef={navigationRef}>
+         <Navigation ref={navigationRef} />
+       </ObserveNavigationProvider>
+     );
+   }
+   ```
+
+   `ObserveNavigationProvider` renders no container of its own, but it must be an ancestor of every screen so `useObserve()` works inside them. Pass the **same** ref to both elements; a ref that is not connected to a container emits no metrics.
+
+With React Navigation v7's default `lazy: true`, unfocused tabs stay unmounted, so their first focus records as `cold_ttr` rather than `warm_ttr`.
+
 In both integrations, `useObserve()` is safe to leave in place even when the integration is disabled or the router package is absent — it falls back to the global `markInteractive`.
+
+### Per-route event params
+
+Navigation events carry these params in addition to any custom ones passed to `markInteractive`:
+
+| Param | Type | Notes |
+|---|---|---|
+| `routeName` | string | Route pattern (`/(tabs)/sessions/[sessionId]`) with Expo Router, route-name path (`/Tabs/Sessions`) with React Navigation. Never contains param values. |
+| `url` | string | Resolved pathname. Expo Router only. |
+| `routeParams` | object | Resolved route params, e.g. `{ sessionId: 'abc' }`. |
+| `isAppLaunch` | boolean | `cold_ttr` only. `true` when measured from process start rather than from a navigation action. |
+| `urlHidden` | boolean | Present as `true` when a filtered param caused `url` to be omitted. See below. |
+
+### Filter sensitive params (SDK 57+)
+
+By default the integrations export the resolved URL and every serializable route and query param. If any of those carry sensitive values, list their keys in `filteredParams`:
+
+```tsx
+Observe.configure({
+  integrations: {
+    'expo-router': { filteredParams: ['userId', 'token'] },
+    // or: 'react-navigation': { filteredParams: ['userId', 'token'] },
+  },
+});
+```
+
+Filtered keys are removed from `routeParams`, and the event drops `url` in favor of `urlHidden: true`. `routeName` is unaffected, because it is a pattern and never contains param values.
+
+### Common integration mistakes
+
+- Calling `Observe.configure()` after mount, or toggling an integration flag mid-session, **throws**. Enable it at module scope.
+- `Calling markInteractive on unmounted screen` or `No metadata available for the current screen` means the call ran outside a screen component or after unmount. Move it into a `useEffect` inside the screen component.
+- Call `useObserve()` inside the screen component, not in a wrapper above it. A screen identity that changes between renders logs a warning.
+- With React Navigation, `markInteractive()` records only once the screen is focused. A call on an unfocused screen updates internal state but emits no `tti` event until focus.
 
 ## Optional — user-defined events (SDK 56+)
 
@@ -266,9 +362,10 @@ function handleOnboardingComplete() {
 | Parameter | Type | Required | Notes |
 |---|---|---|---|
 | `name` | `string` | yes | Stable, dot-separated identifier, e.g. `'report.exported'`. |
-| `options.attributes` | `Record<string, string \| number \| boolean \| array \| nested object>` | no | Structured context attached to the event. |
+| `options.attributes` | `Record<string, string \| number \| boolean \| array \| nested object>` | no | Structured context attached to the event. Other JS values (`Date`, `undefined`, functions) are dropped. |
 | `options.body` | `string` | no | Free-form message complementing the structured attributes. |
 | `options.severity` | `'trace' \| 'debug' \| 'info' \| 'warn' \| 'error' \| 'fatal'` | no | Defaults to `'info'`. |
+| `options.displayName` | `string` | no | Human-friendly label, e.g. `'Onboarding completed'`. Used **only** in the dashboard's session timeline view; grouping still keys off `name`. |
 
 **Attributes** are the primary way to make an event queryable — attach the identifiers and measurements you'll want to filter or break down by:
 
@@ -306,12 +403,72 @@ User-defined events are persisted on-device, batched, and dispatched on the next
 
 User-defined events appear under the **Events** tab in the Observe dashboard, and are queryable from the terminal with `eas observe:events` — see [`./queries.md`](./queries.md).
 
+## Optional — error reporting
+
+`expo-observe` records errors as non-fatal `exception` log events alongside the performance metrics. They arrive by three paths, and they are **not** a replacement for a crash reporter such as Sentry — EAS Observe has no crash reporting yet.
+
+> These APIs ship in `expo-observe` but are not covered by the published docs yet. Verify the exports against the installed package version before relying on them.
+
+**1. Unhandled JS errors — automatic.** A global `ErrorUtils` handler is installed when the package is first imported, which is earlier than any `configure()` call, so errors thrown before configuration are still recorded. React Native's own behavior is unchanged: the red box in development and fatal termination in production still happen. Turn the recording off with `configure({ errorHandlingEnabled: false })`.
+
+**2. Render-phase errors — `<ObserveErrorBoundary>`.** Render errors never reach `ErrorUtils`, so a boundary is the only way to capture them with the React component stack. The boundary records the error and then renders `fallback` in place of the subtree.
+
+```tsx
+import { ObserveErrorBoundary } from 'expo-observe';
+
+<ObserveErrorBoundary
+  fallback={({ error, resetError }) => <ErrorScreen error={error} onRetry={resetError} />}>
+  <Feed />
+</ObserveErrorBoundary>;
+```
+
+`fallback` is required and accepts a React element, `null`, or a function receiving `{ error, resetError }`. `resetError()` clears the caught error and re-mounts the children, so they restart from a clean state. There is no capture-and-rethrow mode — a boundary always renders one of the three fallback forms. Errors that no boundary catches still reach the global handler.
+
+**3. Handled errors — `Observe.reportError(error)`.** Report failures your code caught and recovered from, which reach neither the global handler nor a boundary.
+
+```tsx
+try {
+  await syncCart();
+} catch (error) {
+  Observe.reportError(error);
+}
+```
+
+The value is normalized before it is sent: an `Error` contributes `name`, `message`, and `stack`; any other thrown value (a string, a plain object, a number) is stringified into the message with no stack. `reportError` never throws — it is called from a `catch` block, so a failure inside it must not turn a handled error into an unhandled one.
+
+## Optional — runtime configuration
+
+`Observe.configure()` controls collection and dispatch. Call it at module scope, before mount. Integration flags in particular cannot be toggled at runtime.
+
+| Option | Type | Default | What it does |
+|---|---|---|---|
+| `environment` | string | `process.env.NODE_ENV`, falling back to `'production'` | Metadata tag used to group metrics; filterable in the dashboard. Does not gate dispatch. |
+| `dispatchingEnabled` | boolean | `true` | Master switch. While `false`, pending metrics are dropped, not queued. |
+| `dispatchInDebug` | boolean | `false` | Dispatch metrics collected from debug builds. No effect on release builds. |
+| `sampleRate` | number | `undefined` (all installations) | Fraction of installations that dispatch, in `[0, 1]`. |
+| `errorHandlingEnabled` | boolean | `true` | Record unhandled JS errors as `exception` events. |
+| `integrations` | object | `undefined` | Opt in to `expo-router`, `react-navigation`, or a third-party integration. |
+
+**Sampling** is deterministic per installation: an installation is permanently in-sample or out-of-sample for a given rate, so the slice is stable across launches rather than a random subset of sessions. Out-of-sample installations drop pending metrics instead of accumulating them, so lowering the rate later does not retroactively send earlier sessions. Values outside `[0, 1]` are clamped. Sampling depends on `dispatchingEnabled`.
+
+**Manual flush.** Events dispatch automatically when the app backgrounds — on Android through a background worker once connectivity returns, on iOS when the app resigns active or is about to terminate. Call `await Observe.dispatchEvents()` to flush early, which is mainly useful while testing.
+
+**Custom endpoint.** EAS Observe sends OTLP over HTTP with a JSON payload, posting to `<endpointUrl>/<project-id>/v1/metrics` and `<endpointUrl>/<project-id>/v1/logs`. Point it at any OpenTelemetry-compatible backend or collector through the **app config**, not `configure()`:
+
+```json
+{ "expo": { "extra": { "eas": { "observe": { "endpointUrl": "https://your-endpoint.com" } } } } }
+```
+
+The URL is baked into the native layer at build time, so run `npx expo prebuild` and rebuild after changing it. If the backend expects standard OTLP paths without the project-ID prefix, route through a collector.
+
 ## Quick checklist
 
-- [ ] SDK ≥ 55, EAS project linked.
+- [ ] SDK ≥ 55, EAS project linked, development or production build (not Expo Go).
 - [ ] `expo-observe` installed via `npx expo install`.
 - [ ] Root component exported through `AppMetricsRoot.wrap(...)` (SDK 55) or `ObserveRoot.wrap(...)` (SDK 56+).
 - [ ] `markInteractive()` called from every entry screen once it is genuinely interactive — global `AppMetrics.markInteractive()` on SDK 55, or `useObserve()` hook on SDK 56+.
-- [ ] (Optional, SDK 56+) Per-route metrics enabled via `Observe.configure({ integrations: { ... } })`, plus `<ObserveNavigationContainer>` for React Navigation.
+- [ ] (Optional, SDK 56+) Per-route metrics enabled via `Observe.configure({ integrations: { ... } })`, plus `<ObserveNavigationContainer>` (dynamic) or `<ObserveNavigationProvider>` (static) for React Navigation.
+- [ ] (Optional, SDK 57+) Sensitive route/query params listed in `filteredParams`.
 - [ ] (Optional, SDK 56+) User-defined events emitted via `Observe.logEvent(name, { attributes })` with stable, lowercase, dot-separated names and no PII.
+- [ ] (Optional) `<ObserveErrorBoundary>` around risky subtrees and `Observe.reportError` in recovery paths.
 - [ ] New build produced with `eas build` and metrics visible in the Observe dashboard.

--- a/plugins/expo/skills/eas-observe/references/third-party.md
+++ b/plugins/expo/skills/eas-observe/references/third-party.md
@@ -1,0 +1,136 @@
+# Add an EAS Observe integration to a third-party package
+
+This reference is for **package authors**, not app developers. It describes how a library ships an optional EAS Observe integration so that apps using the library get events about problems that application code cannot detect on its own.
+
+> Source: https://docs.expo.dev/eas/observe/integrations/third-party/ — consult this page for the latest guidance.
+
+App-side setup lives in [`./setup.md`](./setup.md). Querying the resulting events is in [`./queries.md`](./queries.md).
+
+## When to use this
+
+Report actionable issues the developer can fix. Good candidates:
+
+- An image decoded at far higher resolution than the device screen needs.
+- A background task that exceeds its expected duration.
+- A native resource that loads slowly.
+
+Do not use it for general product analytics or for anything the app author could log themselves.
+
+## Requirements
+
+- **Expo SDK 57 or later.** `Observe.registerIntegration()` is not available earlier.
+- The consuming app must already have `expo-observe` installed and a build produced.
+
+## Step 1 — Depend on `expo-observe` optionally
+
+The package must keep working when `expo-observe` is absent. Declare it as an **optional peer dependency** plus a dev dependency for types and tests. Never make it a required runtime dependency.
+
+```json
+{
+  "peerDependencies": { "expo-observe": ">=57.0.0" },
+  "peerDependenciesMeta": { "expo-observe": { "optional": true } },
+  "devDependencies": { "expo-observe": "^57.0.0" }
+}
+```
+
+Load it with `require()` inside `try/catch`, and type it with `typeof import()` so the types survive:
+
+```ts
+// observe.ts
+let observeModule: typeof import('expo-observe') | undefined;
+
+try {
+  observeModule = require('expo-observe') as typeof import('expo-observe');
+} catch {
+  // The integration stays disabled when expo-observe is not installed.
+}
+```
+
+## Step 2 — Declare the integration config
+
+Use declaration merging to add your integration key to `ObserveIntegrationsConfig`:
+
+```ts
+// observe.types.ts
+export type YourPackageIntegrationConfig = {
+  thresholdMs?: number;
+};
+
+declare module 'expo-observe' {
+  interface ObserveIntegrationsConfig {
+    'your-package'?: boolean | YourPackageIntegrationConfig;
+  }
+}
+```
+
+Export this declaration from the package entry point so TypeScript loads it when the app imports your package. App developers then enable it the same way they enable the first-party integrations:
+
+```tsx
+Observe.configure({
+  integrations: {
+    'your-package': true,
+    // or, with options:
+    // 'your-package': { thresholdMs: 1500 },
+  },
+});
+```
+
+## Step 3 — Register the integration
+
+`Observe.registerIntegration(name, callback)` invokes the callback once, when the named integration config becomes available. The callback does not run when the key is omitted or set to `false`.
+
+```ts
+// observe.ts
+export function initObserveIntegration() {
+  // The `typeof window` check skips initialization during server-side rendering on web.
+  if (typeof window !== 'undefined' && observeModule) {
+    const { Observe } = observeModule;
+
+    Observe.registerIntegration('your-package', config => {
+      if (config) {
+        enableObserveIntegration(config === true ? {} : config);
+      }
+    });
+  }
+}
+```
+
+Call the initializer from the package entry point:
+
+```ts
+// index.ts
+import { initObserveIntegration } from './observe';
+
+export type { YourPackageIntegrationConfig } from './observe.types';
+
+initObserveIntegration();
+```
+
+Note the `config === true` normalization: the key accepts either a boolean or an options object, so collapse `true` to `{}` before using it.
+
+## Step 4 — Log events
+
+Emit through `Observe.logEvent()` when the package detects an actionable issue. Guard on both module presence and enablement, so a disabled integration costs nothing.
+
+```ts
+export function logExpensiveOperation(durationMs: number, thresholdMs: number) {
+  if (!observeModule || !enabled) {
+    return;
+  }
+
+  const { Observe } = observeModule;
+
+  Observe.logEvent('your-package.expensive-operation', {
+    severity: 'warn',
+    body: 'Reduce the work performed by this operation or increase the configured threshold.',
+    attributes: { durationMs, thresholdMs },
+  });
+}
+```
+
+Naming rules, matching the app-side event conventions in [`./setup.md`](./setup.md):
+
+- Lowercase, dot-separated, with **your package name as the first segment**: `your-package.expensive-operation`.
+- Keep names stable. The dashboard groups by exact name.
+- No PII in names, attribute keys, or attribute values.
+- Use `severity` to separate warnings from errors, and `body` for the remediation hint. The attributes carry the measurements.


### PR DESCRIPTION
- Align eas-observe skill with current docs
- Add links to new planned doc on eas-cli observe usage (https://app.graphite.com/github/pr/expo/expo/48768)

This should not be merged until the above PR is merged.
