### PR TITLE
fix(eas-app-stores): affirm first-time eas submit works on Google Play

### DIFF
--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/skills/eas-app-stores/references/play-store.md
+++ b/plugins/expo/skills/eas-app-stores/references/play-store.md
@@ -6,6 +6,8 @@
 2. **App Created in Console** - Create your app listing before first submission
 3. **Service Account** - For automated submissions via EAS
 
+Once these are complete, the default `eas submit` works for a first-time submission and creates the app's first release on the internal testing track. Store listing, content rating, and pricing are only required before promoting a release to production.
+
 ## Service Account Setup
 
 ### 1. Create Service Account


### PR DESCRIPTION
# Why

Fix ENG-25835

# How 

Add a statement to affirm first-time eas submit works on Google Play so that it complies with EAS Submit docs here: https://docs.expo.dev/submit/android/

# Test plan

Proofread