### PR TITLE
[expo-upgrade] Add Hermes v1 memory regression notes

### DIFF
--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/skills/expo-upgrade/SKILL.md
+++ b/plugins/expo/skills/expo-upgrade/SKILL.md
@@ -27,6 +27,8 @@ npx expo install expo@next --fix  # install beta
 
 ## Step-by-Step Upgrade Process
 
+> If upgrading from SDK 55 or earlier, skip SDK 56 and upgrade directly to SDK 57. Don't use `expo@57.0.8` or below. SDK 55 with Hermes V1 enabled, SDK 56, and older SDK 57 releases contain a Hermes V1 memory regression that can drastically increase memory usage when using `react-native-worklets` or `react-native-reanimated`.
+
 1. Upgrade Expo and dependencies
 
 ```bash

--- a/plugins/expo/skills/expo-upgrade/SKILL.md
+++ b/plugins/expo/skills/expo-upgrade/SKILL.md
@@ -81,7 +81,7 @@ These steps only apply when `ios/` and/or `android/` directories exist in the pr
 - If using Expo SDK 54 or later, ensure react-native-worklets is installed — this is required for react-native-reanimated to work.
 - Enable React Compiler in SDK 54+ by adding `"experiments": { "reactCompiler": true }` to app.json — it's stable and recommended
 - Delete sdkVersion from `app.json` to let Expo manage it automatically
-- Remove implicit packages from `package.json`: `babel-preset-expo` and `expo-constants`. Remove `@babel/core` only when neither `react-native-worklets` nor `react-native-reanimated` is installed; Yarn installation can fail without it when either package is present.
+- Remove implicit packages from `package.json`: `@babel/core`, `babel-preset-expo`, `expo-constants`.
 - If the babel.config.js only contains 'babel-preset-expo', delete the file
 - If the metro.config.js only contains expo defaults, delete the file
 

--- a/plugins/expo/skills/expo-upgrade/SKILL.md
+++ b/plugins/expo/skills/expo-upgrade/SKILL.md
@@ -81,7 +81,7 @@ These steps only apply when `ios/` and/or `android/` directories exist in the pr
 - If using Expo SDK 54 or later, ensure react-native-worklets is installed — this is required for react-native-reanimated to work.
 - Enable React Compiler in SDK 54+ by adding `"experiments": { "reactCompiler": true }` to app.json — it's stable and recommended
 - Delete sdkVersion from `app.json` to let Expo manage it automatically
-- Remove implicit packages from `package.json`: `@babel/core`, `babel-preset-expo`, `expo-constants`.
+- Remove implicit packages from `package.json`: `babel-preset-expo` and `expo-constants`. Remove `@babel/core` only when neither `react-native-worklets` nor `react-native-reanimated` is installed; Yarn installation can fail without it when either package is present.
 - If the babel.config.js only contains 'babel-preset-expo', delete the file
 - If the metro.config.js only contains expo defaults, delete the file
 
@@ -131,7 +131,9 @@ Remove redundant metro config options:
 
 ## Hermes engine v1
 
-Since SDK 55, users can opt-in to use Hermes engine v1 for improved runtime performance. This requires setting `useHermesV1: true` in the `expo-build-properties` config plugin, and may require a specific version of the `hermes-compiler` npm package. Hermes v1 will become a default in some future SDK release.
+Hermes V1 is the default on SDK 56 and later. SDK 55 apps using Hermes V1, all SDK 56 apps, and SDK 57 apps before `expo@57.0.9` may encounter a memory regression when importing `react-native-worklets` or `react-native-reanimated`. Upgrade directly to SDK 57 and `expo@57.0.9` or later. Do not recommend Worklets Bundle Mode as a production workaround; it is unsupported and experimental and may not work as expected.
+
+Do not guide users to opt in to or out of Hermes V1. Changing the Hermes version from the SDK default is unsupported and has significant build and dependency-management caveats.
 
 ## New Architecture
 


### PR DESCRIPTION
## Summary

See: https://github.com/expo/sync-to-sanity/pull/30
See: https://github.com/expo/expo/pull/48887

- We should instruct SDK 56 to be skipped and add a note on what's affected by the Hermes v1 memory regression
- We should never imply that opting in/out of Hermes v1 is reliable or recommended. It's always unsafe and should be actively discouraged