### PR TITLE
[skills][expo-project-structure] Sketch colocated TypeScript eval

### DIFF
--- a/docs/superpowers/specs/2026-08-17-expo-project-structure-eval-shape-design.md
+++ b/docs/superpowers/specs/2026-08-17-expo-project-structure-eval-shape-design.md
@@ -1,0 +1,91 @@
+# Expo Project Structure Eval Shape
+
+## Status
+
+Approved for a draft, shape-only pull request. The eval is intentionally not executable yet.
+
+## Goal
+
+Show how a normal skill in `expo/skills` could own a colocated, task-oriented TypeScript eval using the style introduced for the `expo-sqlite` skill. The draft gives Expo maintainers concrete files to review before `eval-experiments` learns how to discover and execute them.
+
+## Decisions
+
+- Pilot only `expo-project-structure`.
+- Put the eval under the skill's hidden `.evals/` directory.
+- Define the task and its checks together in TypeScript.
+- Reuse Kudo's `agentEval(..., defineChecks)` style rather than copying the central JSON registry.
+- Keep common scanning, glob, AST, skip, and reporting machinery reusable in `@expo/skill-eval-kit`; do not introduce a global registry of named checks in this repository.
+- Treat this as a draft consumer-contract proposal. Do not vendor an agent runner or create a second implementation of the harness.
+
+## Proposed Files
+
+```text
+plugins/expo/skills/expo-project-structure/
+  .evals/
+    README.md
+    setup.ts
+    001-scaffold-project.eval.ts
+```
+
+`README.md` explains the experimental status, the unavailable dependency, the missing skill-only setup support, and the intended `eval-experiments` follow-up.
+
+`setup.ts` returns a plain setup descriptor for a plugin-owned skill. Unlike the current module-oriented `ProjectSetup`, it identifies the skill directory and base Expo template but has no npm package under test. This is intentionally the consumer-side shape that the eval kit will need to support.
+
+`001-scaffold-project.eval.ts` contains the user task and case-local assertions. It imports the proposed `agentEval` and `expect` surface from `@expo/skill-eval-kit`, matching the SQLite cases.
+
+## Task
+
+The task starts from a blank TypeScript Expo project and asks the agent to scaffold a small Expo Router application with home and settings routes, a reusable button, and a date-formatting utility with a unit test. It asks for a maintainable layout without spelling out the exact directories that the skill recommends.
+
+The same task is intended to run with and without the skill once execution support exists.
+
+## Checks
+
+The case keeps the intent of the current `eval-experiments` coverage but expresses it in task context:
+
+1. Router files live under `src/app/`.
+2. Reusable UI lives under `src/components/` rather than the route directory.
+3. The route directory contains routes and layouts, not reusable components or utilities.
+4. Styles remain in component files; no separate `*.styles.*` files are introduced.
+5. The date utility and its test are colocated; no `__tests__/` directory is introduced.
+6. `tsconfig.json` configures an `@/*` path alias for `src/*`.
+
+These are case-local assertions, not globally registered check IDs. If identical implementation logic recurs in later evals, it can be extracted into typed helper functions without separating the assertions from their tasks.
+
+## Dependency Boundary
+
+`@expo/skill-eval-kit` is not published, and its current draft contract assumes an npm package under test. Therefore this draft does not add a package dependency, run the eval in CI, or claim that the TypeScript compiles against the current kit.
+
+The follow-up work in `eval-experiments` must:
+
+- support plugin-owned skills that have no package to link;
+- discover colocated `.evals` cases from a supplied skills repository;
+- run the coding agent through the shared EAS harness;
+- collect traces, workspaces, structured check results, and reports; and
+- preserve with-skill and without-skill conditions.
+
+## Repository and Packaging Effects
+
+The `.evals` directory will sit inside the skill directory and will currently be copied by `npx skills`; it may also be included in installed plugin payloads. It has no `SKILL.md`, so it is not discovered as a separate skill or automatically loaded into agent context, but the files are still distributed on disk.
+
+This draft accepts that small temporary cost so reviewers can evaluate true colocation. The pull request must call the behavior out explicitly. Before this pattern is rolled out across more skills, move eval assets outside the distributed plugin area unless the supported installation paths gain a reliable shared exclusion mechanism.
+
+The existing central uptake checks in `eval-experiments` remain operational and unchanged. They are not removed until a later integration reads the colocated TypeScript case.
+
+## Verification
+
+For this first PR:
+
+- run the existing `expo/skills` repository validation;
+- format the new TypeScript and Markdown files;
+- inspect that every assertion follows an instruction in `expo-project-structure/SKILL.md`;
+- confirm that the new `.evals` directory is not included by any existing TypeScript build or test suite; and
+- state clearly in the PR body that the eval is illustrative and not yet runnable.
+
+No agent run, EAS workflow run, or uplift result is claimed by this PR.
+
+## Pull Request Positioning
+
+Open the pull request as a draft. The review question is whether this is the right maintainer-owned task/check shape for normal Expo skills. Runtime integration and API finalization belong in follow-up work after maintainers agree on that shape.
+
+The pull request body must also identify distribution of `.evals` as a known temporary compromise and record moving eval assets outside the distributed plugin area as follow-up work.

--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/skills/expo-project-structure/.evals/001-scaffold-project.eval.ts
+++ b/plugins/expo/skills/expo-project-structure/.evals/001-scaffold-project.eval.ts
@@ -1,0 +1,63 @@
+import { agentEval, expect } from '@expo/skill-eval-kit';
+
+import { setupProject } from './setup';
+
+// This is a proposed consumer of a future skill-only agentEval setup. The
+// current kit requires an npm package under test and cannot run this case yet.
+agentEval(
+  import.meta.url,
+  {
+    title: 'scaffold a maintainable Expo Router project',
+    prompt: `You're starting a new Expo Router app for a small task tracker. Add home and settings routes, a reusable primary button shared by both screens, and a date-formatting utility with a unit test. Organize the new project so another team can grow it, use TypeScript throughout, and configure clean non-relative imports. Replace the starter structure as needed.`,
+    projectSetup: setupProject(),
+  },
+  (check) => {
+    check('puts routes under src/app', (ws) => {
+      expect(ws.exists('src/app')).toBe(true);
+      expect(ws.glob('src/app/**/index.tsx').length).toBeGreaterThan(0);
+      expect(ws.glob('src/app/**/*settings*.tsx').length).toBeGreaterThan(0);
+    });
+
+    check('keeps reusable UI under src/components', (ws) => {
+      expect(ws.exists('src/components')).toBe(true);
+      expect(ws.glob('src/components/**/*button*.tsx').length).toBeGreaterThan(0);
+    });
+
+    check('keeps non-route code out of src/app', (ws) => {
+      const misplacedFiles = [
+        ...ws.glob('src/app/**/*button*.ts'),
+        ...ws.glob('src/app/**/*button*.tsx'),
+        ...ws.glob('src/app/**/*date*.ts'),
+        ...ws.glob('src/app/**/*date*.tsx'),
+      ];
+      expect(misplacedFiles).toEqual([]);
+    });
+
+    check('keeps styles with their components', (ws) => {
+      const separateStyleFiles = [
+        ...ws.glob('**/*.styles.ts'),
+        ...ws.glob('**/*.styles.tsx'),
+        ...ws.glob('**/*.styles.js'),
+        ...ws.glob('**/*.styles.jsx'),
+      ];
+      expect(separateStyleFiles).toEqual([]);
+    });
+
+    check('colocates the date utility and its test', (ws) => {
+      const dateUtilities = ws
+        .glob('src/utils/**/*date*.ts')
+        .filter((file) => !file.endsWith('.test.ts'));
+      const dateTests = ws.glob('src/utils/**/*date*.test.ts');
+
+      expect(dateUtilities.length).toBeGreaterThan(0);
+      expect(dateTests.length).toBeGreaterThan(0);
+      expect(ws.glob('**/__tests__/**')).toEqual([]);
+    });
+
+    check('configures the @/* path alias', (ws) => {
+      expect(ws.read('tsconfig.json')).toMatch(
+        /"@\/\*"\s*:\s*\[\s*"\.\/src\/\*"\s*\]/
+      );
+    });
+  }
+);

--- a/plugins/expo/skills/expo-project-structure/.evals/README.md
+++ b/plugins/expo/skills/expo-project-structure/.evals/README.md
@@ -1,0 +1,23 @@
+# Expo project structure evals
+
+This directory sketches the maintainer-owned TypeScript eval shape proposed for the `expo-project-structure` skill. It follows the colocated `agentEval()` style used by the `expo-sqlite` skill in the Expo SDK repository.
+
+## Experimental status
+
+This eval is **not runnable yet**:
+
+- `@expo/skill-eval-kit` is not published.
+- The current draft kit assumes every skill belongs to an npm package under test. This plugin-owned skill has no package to link.
+- The existing `eval-experiments` EAS workflow does not discover or execute evals from `expo/skills`.
+
+The files intentionally show the consumer API we want to discuss before finalizing that runtime contract. Do not vendor an agent runner here.
+
+## Intended execution
+
+Once the shared harness supports plugin-owned skills, it should run this task in both with-skill and without-skill conditions. `eval-experiments` should continue to own agent launch, authentication, traces, artifacts, repetitions, and reporting.
+
+## Distribution note
+
+Because `.evals` currently lives inside the skill directory, `npx skills` copies it and installed plugin payloads may include it. The directory has no `SKILL.md`, so it is not discovered as a separate skill or automatically loaded into agent context.
+
+This is a temporary compromise for reviewing true colocation. Before this pattern is adopted across more skills, move eval assets outside the distributed plugin area unless every supported installer gains a reliable shared exclusion mechanism.

--- a/plugins/expo/skills/expo-project-structure/.evals/setup.ts
+++ b/plugins/expo/skills/expo-project-structure/.evals/setup.ts
@@ -1,0 +1,14 @@
+/**
+ * Proposed setup descriptor for a plugin-owned skill eval.
+ *
+ * The current @expo/skill-eval-kit ProjectSetup requires an npm package under
+ * test. expo-project-structure belongs to the Expo plugin instead, so this
+ * shape deliberately contains only the skill and scaffold facts that a future
+ * shared runner needs.
+ */
+export function setupProject() {
+  return {
+    skillDir: new URL('..', import.meta.url),
+    baseTemplate: 'blank-typescript',
+  } as const;
+}


### PR DESCRIPTION
## Why

This is a draft shape proposal for maintainer-owned evals colocated with a regular Expo skill, modeled after the TypeScript evals being developed for `expo-sqlite`.

Today, the project-structure uptake checks live centrally in `expo/eval-experiments`. This PR explores what it would look like for the skill maintainer to own the task and its assertions beside the skill instead.

## What

- Adds an `.evals` directory to `expo-project-structure`.
- Adds one TypeScript eval case containing both the authoring task and six case-local uptake checks.
- Proposes a skill-only setup shape that points at the colocated skill without pretending it is an npm package.
- Documents how a future `eval-experiments` integration would execute the case in with-skill and without-skill conditions.
- Bumps all Expo plugin manifests from `1.10.2` to `1.10.3`, because the repository's version check treats files under `plugins/expo/skills/` as distributed plugin content.

## Intentionally not runnable yet

This PR is meant to make the proposed ownership and API shape concrete enough to review. It does not introduce a second eval runner.

- `@expo/skill-eval-kit` is not currently published.
- Its current setup contract is oriented around an npm package (`packageName` / `packageRoot`), while this is a plugin-owned skill.
- `expo/eval-experiments` does not yet discover eval cases from this repository.
- No coding-agent launcher is vendored here; the intended follow-up is for the existing EAS-native eval harness to own agent execution, traces, artifacts, condition comparison, and reporting.

## Distribution caveat

Because `.evals` currently sits inside the skill directory, plugin installers may copy these files along with the skill. They do not contain a `SKILL.md`, so they are not a separately discoverable or auto-loaded skill, but they are still unnecessary distribution payload.

That is an accepted temporary cost for this draft so reviewers can evaluate true colocation. Once the shape is agreed, we should move eval assets outside the distributed plugin area unless we establish a reliable exclusion mechanism shared by the supported plugin installers.

## Intended follow-up

1. Extend the eval-kit contract to represent plugin-owned skills.
2. Teach `eval-experiments` to discover these cases from `expo/skills`.
3. Run each task through the existing EAS workflow in with-skill and without-skill conditions.
4. Feed authored code and traces to the uptake analyzer and return terminal results plus the EAS report URL.
5. Move eval assets outside the distributed plugin area before treating this as the repository-wide convention.

## Validation

- Static contract test: 1 pass, 18 assertions.
- TypeScript case bundles successfully with `@expo/skill-eval-kit` marked external.
- `bun scripts/check-skill-limits.ts`
- `claude plugin validate .`
- `claude plugin validate ./plugins/expo`
- Plugin manifests parse as JSON.
- `bun scripts/check-plugin-version-bump.ts origin/main`
- `git diff --check origin/main...HEAD`

No coding-agent or EAS eval was run, by design: the missing runner integration is the follow-up this draft is intended to clarify.
