### PR TITLE
Document explicit Expo Go mode for EAS Simulator

### DIFF
--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/skills/eas-simulator/SKILL.md
+++ b/plugins/expo/skills/eas-simulator/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: eas-simulator
-description: "EAS service (paid). Run and control a user's app on a remote iOS/Android simulator hosted on EAS cloud. Read before running any `eas simulator:*` commands - it has the current syntax for this experimental API. Use whenever the user needs a simulator they can't run locally - 'run my app on a cloud simulator', 'use eas simulator to run/install/screenshot my app', 'I'm on Linux/Cursor and need an iOS device', 'no sim on this box / headless CI', 'let an agent click through my app and screenshot it', 'test my dev build on a remote sim with live reload', 'stream a sim to my browser' - even when they don't say 'EAS Simulator' or 'cloud'. On a host WITHOUT a local simulator (Linux, CI, cloud sandbox) it's the default; on macOS, do NOT auto-trigger for a plain 'run on the simulator' - use it only for a cloud/remote/shareable sim, an iOS version they lack, or an agent-driven session. NOT for local sims (expo run:ios, Xcode, Android Studio), EAS Build/Update, web preview, or physical devices."
+description: "EAS service (paid). Run and control a user's app on a remote iOS/Android simulator hosted on EAS cloud. Read before running any `eas simulator:*` commands - it has the current syntax for this experimental API. Use whenever the user needs a simulator they can't run locally - 'run my app on a cloud simulator', 'use eas simulator to run/install/screenshot my app', 'install Expo Go remotely', 'I'm on Linux/Cursor and need an iOS device', 'no sim on this box / headless CI', 'let an agent click through my app and screenshot it', 'test my dev build on a remote sim with live reload', 'stream a sim to my browser' - even when they don't say 'EAS Simulator' or 'cloud'. On a host WITHOUT a local simulator (Linux, CI, cloud sandbox) it's the default; on macOS, do NOT auto-trigger for a plain 'run on the simulator' - use it only for a cloud/remote/shareable sim, an iOS version they lack, or an agent-driven session. NOT for local sims (expo run:ios, Xcode, Android Studio), EAS Build/Update, web preview, or physical devices."
 version: 1.0.0
 license: MIT
-allowed-tools: "Bash(npx *eas-cli@*), Bash(npx *agent-device@*), Bash(npx expo *), Bash(eas *), Bash(expo *), Bash(xcodebuild*), Bash(pod*), Bash(argent *), Bash(ffmpeg*)"
+allowed-tools: "Bash(npx *eas-cli@*), Bash(npx *agent-device@*), Bash(npx *expo-go@*), Bash(npx expo *), Bash(eas *), Bash(expo *), Bash(xcodebuild*), Bash(pod*), Bash(argent *), Bash(ffmpeg*)"
 ---
 
 # EAS Simulator
@@ -125,22 +125,24 @@ Rules:
 
 ## Running the user's app — pick a mode
 
-The remote sim boots **blank — no Expo Go, no apps.** Install a build, then drive it — but **match the build *type* to the goal first** (the box below); that's where live-session runs derail. Full sequences: [references/run-your-app.md](./references/run-your-app.md) — read before running a mode.
+The remote sim boots **blank — no Expo Go, no apps.** Install the right runtime/build, then drive it — but **match it to the goal first** (the box below); that's where live-session runs derail. Full sequences: [references/run-your-app.md](./references/run-your-app.md) — read before running a mode.
 
 > **Match the build to the goal before installing anything — this is where live-session runs derail.** Two traps, same root (grabbing a build that doesn't fit the request):
-> 1. **Wrong type.** Live edits (Mode C) **require a dev build.** A *static* build — a local Release (A), the default EAS sim build (B), or **any build left on the sim from an earlier screenshot run** — freezes its JS at build time and **can never hot-reload.** For a live request, **ignore existing builds entirely** and install a **dev** build (local Debug, or an EAS build with `developmentClient: true`). Never reconnect Metro to a static build hoping it'll reload — it won't.
+> 1. **Wrong type.** Live edits default to a **dev build (Mode C)**. A *static* build — a local Release (A), the default EAS sim build (B), or **any build left on the sim from an earlier screenshot run** — freezes its JS at build time and **can never hot-reload.** For a live request, **ignore existing builds entirely** and install a **dev** build (local Debug, or an EAS build with `developmentClient: true`). Never reconnect Metro to a static build hoping it'll reload — it won't. **Expo Go (G) is an opt-in exception only when the user explicitly asks for it** and the project is compatible with its bundled native modules.
 > 2. **Stale.** A static look must match current source — reuse only a fingerprint-matched build, else build fresh; reuse is explicit-only.
 >
 > So a leftover EAS/release build is **not** a shortcut for "iterate live" — it's the wrong binary. The fact that a build *exists* never makes it the right one.
 
 | Mode | What it is | Choose when | Live edits? |
 |---|---|---|---|
+| **C — Local dev build + tunnel** | Dev (Debug) build + `EXPO_UNSTABLE_TUNNEL_V2=1 expo start --tunnel` + connect the dev client to Metro | **The default agentic edit-and-see loop** — change code and see it live (Fast Refresh) | **Yes** |
+| **G — Expo Go + tunnel** (explicit-only) | Install the Expo Go binary matching the project's Expo SDK, then connect it to tunneled Metro | **Only when the user explicitly asks for Expo Go** and the project is compatible with Expo Go. A blank remote sim is not evidence that a custom dev build is required. | **Yes** |
 | **A — Local release build** | Build a Release `.app` locally, `agent-device install` it (uploads) | User has a Mac toolchain and wants a quick "run my current code on a cloud device" | No (rebuild to see changes) |
 | **B — EAS build** (rare, explicit-only) | `eas build` a simulator build, `agent-device install-from-source <url>` (the VM downloads it) | **Only when explicitly asked** — the user names an existing/EAS build, or wants a static EAS artifact for CI/sharing. Not for "show me"/"iterate" (use C). Sim builds need no credentials. | No |
-| **C — Local dev build + tunnel** | Dev (Debug) build + `EXPO_UNSTABLE_TUNNEL_V2=1 expo start --tunnel` + connect the dev client to Metro | **The agentic edit-and-see loop** — change code and see it live (Fast Refresh) | **Yes** |
 
-Quick decision — **default to C; A and B are explicit-only:**
+Quick decision — **default to C; G, A, and B are explicit-only:**
 - **C (almost everything):** iterate, interact, poke the app, live edits — *and* most "show me my app" (current code needs a build anyway, so live+current wins). Mac → dev client builds locally; no Mac → build it on EAS (`developmentClient: true`). **Unsure → C.**
+- **G:** only when the user explicitly wants Expo Go. Pin Expo Go to the project's installed `expo` major; never substitute `latest`. If the app needs native code not bundled in Expo Go, explain the incompatibility and recommend C.
 - **A:** only an explicit one-shot **static** screenshot on a Mac.
 - **B:** only when the user names an existing/EAS build or wants a static EAS artifact (CI/sharing) — see the box above for why a static build is the wrong tool for "iterate."
 
@@ -152,8 +154,8 @@ Quick decision — **default to C; A and B are explicit-only:**
 |---|---|
 | `apps --platform ios` | List user-installed apps (the blank sim shows none); add `--all` to include system apps |
 | `install <appId> <path> --platform ios` | Install a local `.app` (uploads it) |
-| `install-from-source <url> --platform ios` | Install from a URL — the VM downloads it (use for EAS artifacts) |
-| `open <appId\|deep-link> --platform ios` | Launch an app (bundle id) or follow an app **deep link** (`exp+slug://…`). A first-time deep link raises a system **"Open in '<app>'?"** dialog — expect it (don't burn a snapshot discovering it) and `press 'label="Open"'` to hand off; it can be slow, so bound it with agent-device's own `--timeout` (e.g. `press 'label="Open"' --timeout 120000`) — **not** a shell `timeout` wrapper (macOS has no `timeout` binary). (Mode C sidesteps this dialog for the Metro-connect link via "Enter URL manually" — see run-your-app.md.) **Not** for the `webPreviewUrl` — that's a browser preview for the user, never the device. |
+| `install-from-source <url> --platform ios` | Install from a URL — the VM downloads it (use for EAS artifacts and Expo Go release URLs) |
+| `open <appId\|deep-link> [url] --platform ios` | Launch an app (bundle id), follow a **deep link** (`exp+slug://…`), or open a URL through an app shell (for example `open "Expo Go" <exp-url>`). A first-time deep link raises a system **"Open in '<app>'?"** dialog — expect it (don't burn a snapshot discovering it) and `press 'label="Open"'` to hand off; it can be slow, so bound it with agent-device's own `--timeout` (e.g. `press 'label="Open"' --timeout 120000`) — **not** a shell `timeout` wrapper (macOS has no `timeout` binary). (Mode C sidesteps this dialog for the Metro-connect link via "Enter URL manually" — see run-your-app.md.) **Not** for the `webPreviewUrl` — that's a browser preview for the user, never the device. |
 | `snapshot -i` | Interactive accessibility tree → `@e1`-style refs |
 | `press <ref\|selector>` | Tap (e.g. `press @e2` or `press 'label="Open"'`) — **the tap verb is `press`, not `tap`** |
 | `fill <ref> "text"` | Type into a field |
@@ -173,13 +175,13 @@ The non-obvious mental model worth internalizing. Specific error→fix lookups (
    - **cwd** — you're in the intended Expo project dir (a misdirected `start`/`exec` sessions the *wrong app* + drops a stray `.env.eas-simulator`; `pwd` / check `app.json`).
    - **session live** — `IN_PROGRESS` via `simulator:get --json` (a stopped session keeps its id + `remoteConfig`, so the dotenv alone isn't proof).
    - **Metro on its own port** — reuse only if you started it this session; else start one on a free port (`--port <N>`, e.g. 8082), don't kill another server to reclaim `:8081` (run-your-app.md).
-   - **build fits intent** — a **release build can't live-reload**; if live edits are wanted and a release build is installed, **install the dev build, don't reconnect**.
+   - **runtime/build fits intent** — a **release build can't live-reload**; if live edits are wanted and a release build is installed, **install the dev build, don't reconnect**. Use Expo Go instead only when the user explicitly requested it.
 
    If current code isn't rendering after your **first** connect, stop poking live state: **reset to baseline** (stop session → clear dotenv → kill your Metro) and redo the mode **once**; a second failure → stop and report. Never restart Metro in place, reconnect more than once, rebuild the native client to fix a JS/connection problem, or surface a preview URL while state is unknown. (A daemon drop — `ERR_NGROK_3200` / `Remote daemon is unavailable` — is the same: reset, don't retry.)
 2. **`exec` is a wrapper, not a driver.** `simulator:exec` loads `.env.eas-simulator` and spawns the command you pass; the device verbs come from the controller (`npx agent-device@latest`). There is no `simulator:tap`.
 3. **Act immediately; don't park an idle session.** Sessions are short-lived — install and drive right after `start`. Leaving one idle drops the tunnel/daemon (→ reset, per #1).
 4. **Stop on every exit path (billing) and reset the dotenv.** `--non-interactive` doesn't auto-stop, and a forgotten session bills until stopped. Don't `start` again to "retry" a slow boot — that orphans a second billed session.
-5. **Screenshot only the correct, fresh build.** Mode C only after the dev client connects to Metro; A/B only from a build matching current source — reusing a pre-existing build is the #1 "my edits don't show" cause (see the build caveat above). (`9:41` in the status bar is the sim default, not staleness.)
+5. **Screenshot only the correct, fresh runtime/build.** Mode C only after the dev client connects to Metro; Mode G only after the SDK-matched Expo Go connects to Metro; A/B only from a build matching current source — reusing a pre-existing build is the #1 "my edits don't show" cause (see the build caveat above). (`9:41` in the status bar is the sim default, not staleness.)
 
 ## Stop and clean up
 
@@ -188,16 +190,16 @@ Stop the session (ends billing) **and reset the dotenv** so a later run doesn't 
 ```bash
 npx --yes eas-cli@latest simulator:stop          # omit --id → stops the dotenv session (or pass --id <id>)
 printf '# managed by eas-cli\n' > .env.eas-simulator   # clear the stale session id so it isn't reused
-# if you started Metro for Mode C, stop it too (Ctrl+C in its terminal, or kill the expo process)
+# if you started Metro for Mode C or G, stop it too (Ctrl+C in its terminal, or kill the expo process)
 ```
 
 ## References
 
-- [references/run-your-app.md](./references/run-your-app.md) — full command sequences for modes A, B, and C (read before running a mode).
+- [references/run-your-app.md](./references/run-your-app.md) — full command sequences for modes G, A, B, and C (read before running a mode).
 - [references/controllers.md](./references/controllers.md) — agent-device verb reference and the `argent` alternative.
 - [references/troubleshooting.md](./references/troubleshooting.md) — concrete errors and fixes.
 
-Source of truth: Expo docs and the `eas` / `agent-device` CLIs (`npx --yes eas-cli@latest simulator:* --help`, `agent-device --help`). This skill teaches how to apply them; it doesn't replace them.
+Source of truth: Expo docs and the `eas`, `expo-go`, `agent-device`, and `argent` CLIs (`npx --yes eas-cli@latest simulator:* --help`, `npx --yes expo-go@latest --help`, controller help). This skill teaches how to apply them; it doesn't replace them.
 
 ## Submitting Feedback
 If you encounter errors, misleading or outdated information in this skill, report it so Expo can improve:

--- a/plugins/expo/skills/eas-simulator/references/controllers.md
+++ b/plugins/expo/skills/eas-simulator/references/controllers.md
@@ -21,7 +21,7 @@ EAS-specific notes:
 
 - **`press`, not `tap`.** The tap verb is `press` — `tap` is not a verb.
 - **`snapshot -i` is slow on iOS** — tens of seconds is normal; wait for it.
-- **`install` uploads** a local binary to the daemon; **`install-from-source`** has the VM download from a URL (use for EAS artifacts — avoids a large upload).
+- **`install` uploads** a local binary to the daemon; **`install-from-source`** has the VM download from a URL (use for EAS artifacts or an Expo Go release URL — avoids a large upload).
 - **Exercised against a live session:** `apps`, `install`, `install-from-source`, `open`, `snapshot -i`, `press`, `fill`, `screenshot`, `scroll`, `gesture` (needs a preset, e.g. `gesture swipe left`), `logs`, `record` (`start`/`stop <path>`), `network`, `perf`. `metro` (`prepare`/`reload`) is the Mode C dev-client bridge. Pass `--platform ios`; run `<verb>` with no args to see its required subcommand/args.
 
 ## argent (alternative)
@@ -39,6 +39,22 @@ argent run reinstall-app --udid <udid> --bundleId <bundle-id> --appPath ./MyApp.
 Whenever the tools client is routed to a remote tool-server, it tars the local bundle and streams it up automatically — no extra flag. "Remote" covers both `argent link` and the env-var MCP config (`ARGENT_TOOLS_URL`), so this works in sandboxed shells too. It's a registry tool, so the MCP server exposes it identically — same call by CLI or MCP. Works for iOS `.app` (a directory), Android `.apk`, and Vega `.vpkg`; the client prints an upload line on stderr.
 
 Needs argent ≥ 0.16.0 (the release that adds tar-upload) — verify with `argent --version`. On older versions `reinstall-app` resolves `--appPath` on the VM only, so a local path fails; drive an app already on the sim instead.
+
+**Expo Go in an argent session.** Use this only for explicit Mode G from `run-your-app.md`. Argent's `reinstall-app` accepts a local `appPath`, not a download URL, so download the SDK-matched binary locally before starting the billed session. `expo-go download` extracts the iOS archive into an `.app` and copies it to the current directory:
+
+```bash
+EXPO_SDK="$(node -p "require('expo/package.json').version.split('.')[0]")"
+EXPO_GO_TMP="$(mktemp -d)"
+( cd "$EXPO_GO_TMP" && npx --yes expo-go@latest download ios "$EXPO_SDK" )
+EXPO_GO_APP="$(find "$EXPO_GO_TMP" -maxdepth 1 -type d -name '*.app' -print -quit)"
+test -n "$EXPO_GO_APP"
+
+# After starting and linking the argent EAS Simulator session:
+argent run reinstall-app --udid <udid> --bundleId host.exp.Exponent --appPath "$EXPO_GO_APP"
+argent run open-url --udid <udid> --url "<exp:// or exps:// URL from Metro>"
+```
+
+For Android, run `expo-go download android "$EXPO_SDK"`, select the downloaded `.apk`, and use bundle id `host.exp.exponent`. The temporary directory can be discarded after the upload. Never pass the EAS Simulator `webPreviewUrl` to `open-url`; use the Expo project URL printed by `npx expo start --go --tunnel`.
 
 **System dialogs on argent (e.g. the first-time deep-link "Open in '<app>'?").** argent's UI queries (`describe` / `await-ui-element`) may not see system dialogs / native modals — a screenshot shows the dialog, but element lookups time out. When that happens, argent surfaces a hint with the fix (today that's a `boot-device --force` to switch its AX backend); follow the hint, then locate and tap "Open". There's no single press-with-timeout — you wait for the element, then tap it. Use argent's own command help for the exact tools and flags.
 

--- a/plugins/expo/skills/eas-simulator/references/run-your-app.md
+++ b/plugins/expo/skills/eas-simulator/references/run-your-app.md
@@ -1,8 +1,8 @@
 # Running your app on the remote sim — tested sequences
 
-The remote sim boots blank. You install a **simulator-targeted** build onto the session, then open it. Pick a mode from `SKILL.md`. (Sequences validated against eas-cli 20.3.x + agent-device 0.17.x in mid-2026; the commands are experimental — if one fails, re-check `<cmd> --help`.)
+The remote sim boots blank. You install a **simulator-targeted runtime or build** onto the session, then open it. Pick a mode from `SKILL.md`. (Modes A/B/C were validated against eas-cli 20.3.x + agent-device 0.17.x in mid-2026; Mode G uses the current documented `expo-go` and controller command surfaces. The commands are experimental — if one fails, re-check `<cmd> --help`.)
 
-In all modes, the session is started the same way and driven through `npx --yes eas-cli@latest simulator:exec`. Replace `dev.example.app` with the app's iOS `bundleIdentifier` (from `app.json` → `ios.bundleIdentifier`), and run from the project directory.
+In all modes, the session is started the same way and driven through `npx --yes eas-cli@latest simulator:exec`. For modes A/B/C, replace `dev.example.app` with the app's iOS `bundleIdentifier` (from `app.json` → `ios.bundleIdentifier`). Run from the project directory.
 
 > These sequences are **iOS**. For **Android**: build via `npx --yes eas-cli@latest build --platform android` (or local Gradle), `install` the `.apk` instead of an `.app`, skip `pod install`, and note there's **no `webPreviewUrl`** (Android is agent-driven / screenshot-only).
 
@@ -32,6 +32,55 @@ done
 ```
 
 If you need the id explicitly, it's `EAS_SIMULATOR_SESSION_ID` in `.env.eas-simulator`. `start` also prints a `webPreviewUrl` (iOS-only browser preview — surface it per the SKILL.md "watch it live" rules) and a job-run URL. Once live, the session env is in `.env.eas-simulator`, so `simulator:exec` works.
+
+---
+
+## Mode G — Expo Go + tunnel (explicit-only)
+
+Use this mode **only when the user explicitly asks for Expo Go**. The default live-edit path remains Mode C with a development build. Expo Go is appropriate only when the app's native dependencies are bundled in Expo Go; if they are not, explain that limitation and recommend Mode C instead.
+
+Expo Go must match the project's Expo SDK. The installed `expo` package determines that SDK — do not use `latest` as the SDK argument, because the newest Expo Go may reject an older project. (`expo-go@latest` below updates the resolver CLI, not the selected SDK.) If app config has an explicit `sdkVersion`, it must agree with the installed `expo` major; fix a mismatch instead of guessing which one to install.
+
+Do the URL lookup and start Metro **before** starting the billed simulator session:
+
+```bash
+# 1. Resolve the project SDK from the installed expo package.
+EXPO_SDK="$(node -p "require('expo/package.json').version.split('.')[0]")"
+
+# 2. Resolve the matching iOS Simulator build. expo-go writes progress to stderr;
+#    the sed expression turns its final stdout line into a bare URL.
+EXPO_GO_URL="$(
+  npx --yes expo-go@latest url ios "$EXPO_SDK" |
+    sed -n 's/^Download Expo Go from //p'
+)"
+test -n "$EXPO_GO_URL"
+
+# 3. Start Expo CLI explicitly in Expo Go mode on its own port. Keep this process alive.
+EXPO_UNSTABLE_TUNNEL_V2=1 npx expo start --go --tunnel --port <N>
+# → capture the exp:// or exps:// project URL printed by Metro.
+```
+
+Once Metro is ready, start the shared session from the section above, then install and open Expo Go:
+
+```bash
+# 4. Let the remote VM download and install the matching Expo Go archive.
+npx --yes eas-cli@latest simulator:exec \
+  npx agent-device@latest install-from-source "$EXPO_GO_URL" --platform ios
+
+# 5. Open the Metro project through the Expo Go shell. This is the Expo project URL,
+#    never the EAS Simulator webPreviewUrl.
+npx --yes eas-cli@latest simulator:exec \
+  npx agent-device@latest open "Expo Go" "<exp:// or exps:// URL from Metro>" --platform ios
+
+# 6. Verify, then stop the billed session and Metro.
+npx --yes eas-cli@latest simulator:exec npx agent-device@latest snapshot -i
+npx --yes eas-cli@latest simulator:exec npx agent-device@latest screenshot ./expo-go.png
+npx --yes eas-cli@latest simulator:stop
+printf '# managed by eas-cli\n' > .env.eas-simulator
+# Stop Metro in its long-lived terminal (Ctrl+C).
+```
+
+For Android, change both platform arguments to `android`; `expo-go url` returns the matching `.apk`. For an **argent** session, do not use agent-device's URL installer — read the Expo Go branch in [controllers.md](./controllers.md), which downloads the artifact locally and uploads it with `reinstall-app`.
 
 ---
 

--- a/plugins/expo/skills/eas-simulator/references/troubleshooting.md
+++ b/plugins/expo/skills/eas-simulator/references/troubleshooting.md
@@ -22,6 +22,8 @@ Concrete errors seen while validating this flow, and the fix.
 | New session's id shows as the *previous* one; "Overwriting previous simulator session (id: …)" | The stale `.env.eas-simulator` had an old `EAS_SIMULATOR_SESSION_ID`; the warning line masks the new id | Reset the dotenv before `start`: `printf '# managed by eas-cli\n' > .env.eas-simulator`. |
 | No `.env.eas-simulator` written after `start` | `--json` suppresses the dotenv | Run `start` *without* `--json` for the `exec` flow; with `--json` you must read `remoteConfig` from stdout and set the env yourself. |
 | `pod install` fails: `Unicode Normalization not appropriate for ASCII-8BIT` | Ruby 4 + CocoaPods with a non-UTF-8 locale | Re-run with `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 pod install`. |
+| (Mode G) Expo Go says the project is incompatible with this version | Expo Go was resolved with `latest`, or app config has an `sdkVersion` that disagrees with the installed `expo` package | Resolve the SDK from `require('expo/package.json').version`, then run `npx --yes expo-go@latest url <platform> <sdk-major>` and reinstall. If app config explicitly sets `sdkVersion`, make it match the installed `expo` major. |
+| (Mode G) Expo Go opens but a native module is missing/unsupported | The project needs native code that is not bundled in Expo Go | Don't patch around it or try another Expo Go version. Explain the limitation and recommend the default Mode C development build. |
 | (Mode C) Deep-link `open` lands on the dev-client launcher, not the app | Opening the deep link triggers a system "Open in '<app>'?" dialog; and the launcher only auto-discovers Metro on the LAN | `press 'label="Open"'` to dismiss the dialog, then "Enter URL manually" → `fill` the `https://<host>.on.expo.app` manifest URL → "Connect". |
 | (Mode C) App shows expo-router "Unmatched Route" | The connect URL was parsed as a route path | `press 'label="Go back"'` (or navigate to `/`). |
 | (Mode C) Dev client shows a `?` placeholder / blank after connect | Bundle not fetched yet | `press 'label="Reload"'` and wait ~40-60s for the first build+transfer over the tunnel. |
@@ -38,4 +40,4 @@ Concrete errors seen while validating this flow, and the fix.
 Set the user's expectations honestly — this is experimental:
 - **Boot is variable**: ~90s warm to ~15 min cold. Poll patiently.
 - **`snapshot` can be slow** on iOS (tens of seconds).
-- **First bundle load** over the tunnel (Mode C) is the slow part; subsequent Fast Refreshes are fast.
+- **First bundle load** over the tunnel (Mode C or explicit Mode G) is the slow part; subsequent Fast Refreshes are fast.


### PR DESCRIPTION
## Summary

- Keep development clients as the default runtime for EAS Simulator live-edit sessions.
- Add an explicit-only Expo Go mode that resolves the binary from the project's installed Expo SDK.
- Document direct URL installation with agent-device and the local download/upload path for Argent.
- Add focused troubleshooting for SDK mismatches and unsupported native modules.
- Bump all Expo plugin manifests to 1.10.3.

## Why

Remote EAS simulators boot blank, which can lead agents to assume a custom development build is always required. When a user explicitly wants Expo Go, the skill should install the SDK-compatible Expo Go binary reliably while continuing to guide normal agentic workflows toward development clients.

## Impact

This makes the runtime decision explicit: Mode C development clients remain the default, while Mode G Expo Go is opt-in and guarded by project compatibility. It also avoids installing the latest incompatible Expo Go version for older SDK projects.

