### PR TITLE
[skills] add expo animation skill and upstream sync

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,6 +147,12 @@ run that skill's own validation.
 prefixes and paid costs callout (step 4), the Codex agent file and its paid prefix (step 7), the
 `skills.sh.json` grouping (step 8), and the feedback block (step 9) all fail CI when violated.
 
+### Syncing `expo-animation`
+
+`expo-animation` mirrors `skills/animate-expo` from `emilkowalski/skills`. Pull upstream changes
+with `bun scripts/sync-animate-expo.ts`; use `--check` to detect drift without writing. The script
+preserves this repository's skill name, category metadata, collaboration notice, and feedback block.
+
 ### Conventions
 
 - MIT license for every skill; use `@expo.io` or `@expo.dev` author emails.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Free, open-source Expo SDK and React Native skills.
 | --- | --- |
 | `expo-project-structure` | Folder structure for a new Expo app: `src/` layout, routes-only `app/`, screens, server code, platform-specific files. |
 | `expo-router` | Expo Router navigation: file-based routes, links, native stacks, modals, sheets, native tabs, and headers. |
+| `expo-animation` | Polished React Native animations and gestures with Reanimated, Gesture Handler, Expo Router, and expo-haptics. |
 | `expo-native-ui` | Native-feeling screen styling, semantic colors, controls, icons, media, animations, and visual effects. |
 | `expo-design-system` | In-app design systems: a token theme (color, spacing, typography, radius, shadow, motion), reusable component conventions, and design-system drift audits. |
 | `expo-ui` | `@expo/ui` native components: universal cross-platform first, with SwiftUI and Jetpack Compose for platform-specific needs. |

--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/README.md
+++ b/plugins/expo/README.md
@@ -10,6 +10,7 @@ Skills come in two groups so the free vs paid boundary stays clear: open-source 
 
 - Recommends a starting folder structure for new projects
 - Provides UI guidelines following Apple Human Interface Guidelines
+- Builds polished, accessible React Native animations and gestures that stay off the JS thread
 - Builds in-app design systems: token themes, reusable component conventions, and style audits
 - Covers Expo Router navigation patterns (stacks, tabs, modals, sheets)
 - Explains native iOS controls, SF Symbols, animations, and visual effects
@@ -39,6 +40,7 @@ Skills come in two groups so the free vs paid boundary stays clear: open-source 
 
 - Building new Expo apps from scratch
 - Adding navigation, styling, or animations
+- Building or fixing animations, gestures, transitions, press feedback, or haptics
 - Setting up a theme with design tokens, or standardizing styles across screens
 - Wiring up data fetching
 - Integrating web libraries via DOM components
@@ -69,6 +71,7 @@ Skills come in two groups so the free vs paid boundary stays clear: open-source 
 
 - **expo-project-structure** - Recommended folder structure for new Expo projects
 - **expo-router** - Navigation and routing: file-based routes, links, native stacks, modals, sheets, native tabs, and headers
+- **expo-animation** - Build polished animations and gestures with Reanimated, Gesture Handler, Expo Router, and expo-haptics
 - **expo-native-ui** - Build beautiful native-feeling screens: styling, semantic colors, controls, icons, media, animations, and visual effects
 - **expo-design-system** - Build a design system inside an app: token theme (color, spacing, typography, radius, shadow, motion), reusable component conventions, and design-system drift audits
 - **expo-ui** - Native UI with @expo/ui: universal cross-platform components first, with SwiftUI and Jetpack Compose for platform-specific needs

--- a/plugins/expo/skills/README.md
+++ b/plugins/expo/skills/README.md
@@ -10,6 +10,7 @@ Free, open-source Expo SDK and React Native skills. Descriptions are prefixed `F
 | --- | --- |
 | `expo-project-structure` | Folder structure for a new Expo app: `src/` layout, routes-only `app/`, screens, server code, platform-specific files. |
 | `expo-router` | Expo Router navigation: file-based routes, links, native stacks, modals, sheets, native tabs, and headers. |
+| `expo-animation` | Polished React Native animations and gestures with Reanimated, Gesture Handler, Expo Router, and expo-haptics. |
 | `expo-native-ui` | Native-feeling screen styling, semantic colors, controls, icons, media, animations, and visual effects. |
 | `expo-design-system` | In-app design systems: a token theme (color, spacing, typography, radius, shadow, motion), reusable component conventions, and design-system drift audits. |
 | `expo-ui` | `@expo/ui` native components: universal cross-platform first, plus SwiftUI and Jetpack Compose. |

--- a/plugins/expo/skills/expo-animation/LICENSE
+++ b/plugins/expo/skills/expo-animation/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Emil Kowalski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/expo/skills/expo-animation/RECIPES.md
+++ b/plugins/expo/skills/expo-animation/RECIPES.md
@@ -1,0 +1,385 @@
+# Expo Animation Recipes
+
+Ready-to-build implementations for the cases that come up most in a React Native app. Start from the recipe, then adapt.
+
+---
+
+## Setup the recipes assume
+
+```bash
+npx expo install react-native-reanimated react-native-worklets react-native-gesture-handler expo-haptics
+```
+
+(`react-native-keyboard-controller` only for the keyboard recipe.) `expo install`, not `npm install` — it resolves the versions that match the SDK. The worklets Babel plugin is configured by `babel-preset-expo` automatically.
+
+`GestureHandlerRootView` wraps the app once — in Expo Router, the root `_layout`:
+
+```jsx
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+
+export default function RootLayout() {
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <Stack />
+    </GestureHandlerRootView>
+  );
+}
+```
+
+Imports and constants every recipe below shares:
+
+```js
+import { useState, useEffect, useMemo } from 'react';
+import Animated, {
+  useSharedValue, useAnimatedStyle, useAnimatedScrollHandler, useAnimatedReaction,
+  withSpring, withTiming, interpolate, Extrapolation, Easing,
+  FadeInDown, FadeOutDown, LinearTransition,
+} from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { scheduleOnRN } from 'react-native-worklets';
+import * as Haptics from 'expo-haptics';
+
+const EASE_OUT = Easing.bezier(0.23, 1, 0.32, 1);      // strong ease-out for UI
+const EASE_IN_OUT = Easing.bezier(0.77, 0, 0.175, 1);  // on-screen movement
+const EASE_SHEET = Easing.bezier(0.32, 0.72, 0, 1);    // iOS sheet curve
+```
+
+Three conventions, explained once here instead of in every recipe:
+
+- **Shared values are read and written with `.get()` / `.set()`**, the form the Reanimated docs recommend for React Compiler support. `.value` still works, but the compiler can't see through it.
+- **`scheduleOnRN(fn, ...args)` replaces the deprecated `runOnJS(fn)(...args)`** for calling back to the React Native runtime from a worklet.
+- **Gestures are wrapped in `useMemo`.** Rebuilding a gesture on every render can reattach the recognizer and drop a drag that's mid-flight.
+
+**Gesture Handler v3:** Expo installs v2, and the recipes use its `Gesture.Pan()` builder. If the project is already on v3, the builder is legacy — each gesture is a hook taking one config object, with `onStart` → `onActivate`, `onEnd` → `onDeactivate`, and the `success` flag replaced by `event.canceled` (inverted). The hook manages its own identity, so drop the `useMemo`:
+
+```jsx
+const pan = usePanGesture({
+  activeOffsetY: [-10, 10],
+  onActivate: () => { context.set(translateY.get()); },
+  onUpdate: (e) => { translateY.set(context.get() + e.translationY); },
+  onDeactivate: (e) => { /* settle with withSpring as below */ },
+});
+```
+
+---
+
+## Two worklets you'll need everywhere
+
+Momentum projection decides *where a flick was going*, so a fast short swipe commits and a slow long one doesn't. Rubber-banding makes a boundary resist instead of stopping dead.
+
+```js
+// Where the finger would come to rest if it kept decelerating.
+// Apple's exponential-decay form — not the v²/2a from physics class.
+function project(velocity, decelerationRate = 0.998) {
+  'worklet';
+  return ((velocity / 1000) * decelerationRate) / (1 - decelerationRate);
+}
+
+// The further past the edge, the less the element follows.
+function rubberband(overshoot, dimension, constant = 0.55) {
+  'worklet';
+  return (overshoot * dimension * constant) / (dimension + constant * Math.abs(overshoot));
+}
+```
+
+---
+
+## Press feedback
+
+Every pressable in the app. This passes the frequency gate only because it's near-imperceptible: 120ms and a 3% scale is the ceiling for something touched this often — anything longer or larger belongs to rarer moments, per step 1 in SKILL.md. No gesture, no shared value — a CSS transition is the whole implementation.
+
+```jsx
+import Animated from 'react-native-reanimated';
+import { Pressable, StyleSheet } from 'react-native';
+
+function PressableScale({ onPress, children }) {
+  const [pressed, setPressed] = useState(false);
+  return (
+    <Pressable
+      onPress={onPress}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
+      hitSlop={12}
+      pressRetentionOffset={16}
+    >
+      <Animated.View style={[styles.box, pressed && styles.pressed]}>{children}</Animated.View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  box: {
+    transform: [{ scale: 1 }],
+    transitionProperty: 'transform',
+    transitionDuration: '120ms',
+    transitionTimingFunction: 'cubic-bezier(0.23, 1, 0.32, 1)',
+  },
+  pressed: { transform: [{ scale: 0.97 }] },
+});
+```
+
+`setState` is fine here — it fires twice per press, not per frame. `hitSlop` brings a small icon up to the 44pt target without growing it; `pressRetentionOffset` stops a slight finger drift from cancelling.
+
+---
+
+## Bottom sheet you can drag to dismiss
+
+Before writing this: if the sheet is its own destination, use `presentation: 'formSheet'` (see **Screen transitions**) and get the platform's real sheet for free. Build this only when the sheet has to live inside an existing screen.
+
+```jsx
+const translateY = useSharedValue(0);
+const context = useSharedValue(0);
+
+const pan = useMemo(() => Gesture.Pan()
+  .activeOffsetY([-10, 10])   // let a horizontal swipe win; require intent before committing
+  .onStart(() => {
+    context.set(translateY.get());   // start from the current on-screen value, not from 0
+  })
+  .onUpdate((e) => {
+    const next = context.get() + e.translationY;
+    // downward is free; upward past the top resists
+    translateY.set(next >= 0 ? next : rubberband(next, HEIGHT));
+  })
+  .onEnd((e) => {
+    const projected = translateY.get() + project(e.velocityY);
+    if (projected > HEIGHT * 0.4) {
+      translateY.set(withSpring(HEIGHT, {
+        duration: 300, dampingRatio: 1, velocity: e.velocityY, overshootClamping: true,
+      }, (finished) => { if (finished) scheduleOnRN(onClose); }));
+    } else {
+      translateY.set(withSpring(0, { duration: 300, dampingRatio: 0.8, velocity: e.velocityY }));
+      scheduleOnRN(Haptics.impactAsync, Haptics.ImpactFeedbackStyle.Light);   // it snapped home
+    }
+  }), [onClose]);
+
+const sheetStyle = useAnimatedStyle(() => ({ transform: [{ translateY: translateY.get() }] }));
+```
+
+The four details that separate this from a bad drag:
+
+- **`onStart` captures the current value.** Without it, grabbing a sheet mid-animation teleports it — the animation must continue from where the eye last saw it.
+- **Velocity decides, not distance.** `project()` means a quick flick dismisses even a few pixels down. Requiring 40% travel makes the sheet feel heavy.
+- **Velocity is handed to the spring**, so there's no seam between the finger releasing and the animation continuing. This is the single detail that most separates "fluid" from "fine".
+- **`overshootClamping` on dismissal** — otherwise the sheet springs past the bottom of the screen and flashes a gap.
+
+The backdrop derives from the same value, so it's always in sync and costs nothing:
+
+```jsx
+const backdropStyle = useAnimatedStyle(() => ({
+  opacity: interpolate(translateY.get(), [0, HEIGHT], [1, 0], Extrapolation.CLAMP),
+}));
+```
+
+---
+
+## Swipe to delete a row
+
+Before writing this: gesture-handler ships [`ReanimatedSwipeable`](https://docs.swmansion.com/react-native-gesture-handler/docs/components/reanimated_swipeable/), which already does swipe-to-reveal actions — thresholds, overshoot, open/close methods — on the UI thread. Reach for it when the row reveals action buttons. Build the gesture yourself only when the interaction is different in kind: swipe-to-commit with momentum projection, like this one.
+
+```jsx
+const x = useSharedValue(0);
+const context = useSharedValue(0);
+
+const pan = useMemo(() => Gesture.Pan()
+  .activeOffsetX([-10, 10])   // must declare the axis, or it fights the vertical scroll
+  .onStart(() => { context.set(x.get()); })   // grab mid-spring continues from where the row is, not from 0
+  .onUpdate((e) => { x.set(Math.min(0, context.get() + e.translationX)); })
+  .onEnd((e) => {
+    const projected = x.get() + project(e.velocityX);
+    if (projected < -SWIPE_THRESHOLD) {
+      x.set(withTiming(-WIDTH, { duration: 200, easing: EASE_OUT }, (f) => {
+        if (f) scheduleOnRN(onDelete, id);
+      }));
+    } else {
+      x.set(withSpring(0, { duration: 300, dampingRatio: 1, velocity: e.velocityX }));
+    }
+  }), [onDelete, id]);
+```
+
+Closing the gap the deleted row left is the list's job, not the row's:
+
+```jsx
+const ROW_CLOSE = LinearTransition.duration(200);   // module scope — builders rebuilt in render cost every re-render
+
+<Animated.FlatList data={items} itemLayoutAnimation={ROW_CLOSE} ... />
+```
+
+`activeOffsetX` is the mobile-specific part. A pan handler inside a scroll view with no axis declared will steal vertical scrolls, and the list will feel broken in a way that looks like a scrolling bug rather than a gesture bug.
+
+---
+
+## Collapsing header on scroll
+
+```jsx
+const scrollY = useSharedValue(0);
+const onScroll = useAnimatedScrollHandler((e) => { scrollY.set(e.contentOffset.y); });
+
+const titleStyle = useAnimatedStyle(() => ({
+  opacity: interpolate(scrollY.get(), [0, 60], [1, 0], Extrapolation.CLAMP),
+  transform: [{ translateY: interpolate(scrollY.get(), [0, 60], [0, -12], Extrapolation.CLAMP) }],
+}));
+
+<Animated.ScrollView onScroll={onScroll} scrollEventThrottle={16}>
+```
+
+**Never animate the header's `height` to collapse it.** That runs a layout pass on the header and everything below it on every scroll frame — the one animation guaranteed to stutter, because it's competing with the scroll itself. Give the container a fixed height and translate the content inside it, clipping with `overflow: 'hidden'`.
+
+`Extrapolation.CLAMP` is not optional: without it, scrolling past 60 keeps driving opacity negative and the header reappears inverted at the bottom of a long list.
+
+---
+
+## List entrances
+
+```jsx
+// The Reanimated docs recommend building layout animations outside components,
+// or in useMemo — an inline chain in JSX rebuilds the builder on every render.
+// A per-index delay can't live at module scope, so the row memoizes its own:
+function Row({ item, index }) {
+  const entering = useMemo(() => FadeInDown.duration(250).delay(index * 40), [index]);
+  return <Animated.View entering={entering}>{/* ... */}</Animated.View>;
+}
+
+{items.map((item, i) => <Row key={item.id} item={item} index={i} />)}
+```
+
+Stagger 30–80ms. Longer feels slow, shorter reads as simultaneous.
+
+**Never put `entering` on a row inside `FlatList`, `FlashList`, or any virtualized list.** Rows are recycled, so the animation re-fires every time one scrolls back into view — the list appears to flicker while the user scrolls. Animate the list container once on mount, or use `itemLayoutAnimation` for reflow only.
+
+Entrance animations are for content the user asked for and is waiting on. A list they scroll past all day should already be there.
+
+---
+
+## Keyboard-synced UI
+
+Needs its own module and a one-time provider ([Expo keyboard guide](https://docs.expo.dev/guides/keyboard-handling/)):
+
+```bash
+npx expo install react-native-keyboard-controller
+```
+
+```jsx
+import { KeyboardProvider } from 'react-native-keyboard-controller';
+
+// Root _layout, next to GestureHandlerRootView — hooks below do nothing without it.
+<KeyboardProvider>
+  <Stack />
+</KeyboardProvider>
+```
+
+```jsx
+import { useReanimatedKeyboardAnimation } from 'react-native-keyboard-controller';
+
+const { height } = useReanimatedKeyboardAnimation();   // 0 → -keyboardHeight, on the UI thread
+const footerStyle = useAnimatedStyle(() => ({ transform: [{ translateY: height.get() }] }));
+```
+
+Never build this from `Keyboard.addListener` plus a timing animation. The keyboard rides a private system curve, the event arrives on the JS thread after the keyboard has already started moving, and any duration you pick will visibly lag or lead it. The UI must be driven by the keyboard's actual position, frame by frame.
+
+---
+
+## Tab / segmented indicator
+
+Measure once, then animate transforms.
+
+```jsx
+const [layouts, setLayouts] = useState({});   // measured with onLayout, not per frame
+const x = useSharedValue(0);
+const w = useSharedValue(0);
+
+useEffect(() => {
+  const l = layouts[active];
+  if (!l) return;
+  x.set(withTiming(l.x, { duration: 250, easing: EASE_IN_OUT }));
+  w.set(withTiming(l.width, { duration: 250, easing: EASE_IN_OUT }));
+}, [active, layouts]);
+
+const pillStyle = useAnimatedStyle(() => ({
+  transform: [{ translateX: x.get() }],
+  width: w.get(),
+}));
+```
+
+This is the sanctioned `width` animation: the pill is absolutely positioned with no children, so nothing else re-lays-out, and its corner radius survives — `scaleX` would smear the corners into ovals.
+
+`ease-in-out`, because the pill is moving across the screen rather than entering or leaving it. Fire `Haptics.selectionAsync()` on the press, not when the pill lands.
+
+---
+
+## Screen transitions (Expo Router)
+
+Configure the native stack. Never rebuild a screen transition in JS: the native one runs on the platform side, keeps the interactive back gesture, and matches every other app on the device.
+
+```jsx
+<Stack screenOptions={{ animation: reduced ? 'fade' : 'default' }}>
+  <Stack.Screen name="settings" options={{ animation: 'slide_from_right', animationMatchesGesture: true }} />
+  <Stack.Screen name="compose" options={{ presentation: 'modal' }} />
+  <Stack.Screen name="filter" options={{
+    presentation: 'formSheet',
+    sheetAllowedDetents: 'fitToContents',
+    sheetGrabberVisible: true,
+  }} />
+</Stack>
+```
+
+| Navigation | Option |
+| --- | --- |
+| Deeper into a hierarchy | `animation: 'default'` — the platform push, unmodified |
+| A self-contained task the user can abandon | `presentation: 'modal'` |
+| A short interruption: picker, filter, share | `presentation: 'formSheet'` with detents |
+| Between tabs | `animation: 'none'` |
+| Reduced motion | `animation: 'fade'` |
+
+`animationMatchesGesture: true` makes the iOS back swipe run your transition in reverse under the finger, instead of the default push. Set it whenever you set a custom `animation`, or dragging back looks like a different app than pushing forward.
+
+`formSheet` is native on both platforms, but not the same on both — the [Expo modal docs](https://docs.expo.dev/router/advanced/modals/#form-sheet-presentation) have the full list:
+
+- **Android caps detents at three.** A longer `sheetAllowedDetents` array works on iOS and silently truncates on Android — design for three.
+- **`sheetGrabberVisible` is iOS-only.** Android shows no grabber; don't rely on it as the only "this is draggable" affordance.
+- **Android form sheets can't host native headers or nested stacks.** Keep the sheet's content a single screen; if it needs its own navigation, use `presentation: 'modal'` instead.
+- **`fitToContents` needs explicitly sized content.** A `flex: 1` root has no intrinsic height to fit — size the content, or the detent is wrong.
+
+---
+
+## Toast
+
+```jsx
+// Module scope — layout-animation builders live outside the component.
+const TOAST_ENTER = FadeInDown.duration(300).easing(EASE_OUT);
+const TOAST_EXIT = FadeOutDown.duration(250).easing(EASE_OUT);
+
+<Animated.View
+  entering={TOAST_ENTER}
+  exiting={TOAST_EXIT}
+  style={{ position: 'absolute', bottom: insets.bottom + 16, left: 16, right: 16 }}
+/>
+```
+
+- **The 300ms cap holds here too.** A toast isn't an exception — it's uninvited, so if anything it should be quicker and quieter than motion the user asked for.
+- **It exits the way it entered.** Entering from the bottom and leaving to the side reads as two unrelated elements.
+- **Exit ~20% faster than entry.** The user has finished reading; the arrival deserves the time, the departure doesn't.
+- **Safe area insets, always.** A toast at `bottom: 16` sits under the home indicator on every modern iPhone.
+
+If toasts stack and the list reflows, add `itemLayoutAnimation` and expect to tune the opacity against the reflow by eye — there's no formula for that pair. Look at it again the next day.
+
+---
+
+## Firing something once at a threshold
+
+When a crossing point matters — a detent, a snap, a pull-to-refresh arming — don't poll it from JS and don't `scheduleOnRN` every frame.
+
+```jsx
+const armed = useSharedValue(false);
+
+useAnimatedReaction(
+  () => pullDistance.get() > REFRESH_THRESHOLD,
+  (isArmed, wasArmed) => {
+    if (isArmed !== wasArmed) {
+      armed.set(isArmed);
+      scheduleOnRN(Haptics.impactAsync, Haptics.ImpactFeedbackStyle.Light);
+    }
+  }
+);
+```
+
+The comparison runs on the UI thread every frame; the JS call happens twice per pull. That's the pattern for every "do something when the animation reaches X".

--- a/plugins/expo/skills/expo-animation/SKILL.md
+++ b/plugins/expo/skills/expo-animation/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: expo-animation
+description: Framework (OSS). Build animations in React Native and Expo, making the decisions in the order that determines whether they feel right — should it animate, which thread it runs on, which properties, spring or timing, how the gesture hands off, how it degrades. Writes the implementation with Reanimated, Gesture Handler, Expo Router and expo-haptics. Use when animating anything in an Expo app, adding gestures, sheets, screen transitions, press feedback or haptics, or fixing motion that stutters on device. For web animation use `animate`.
+version: 1.0.0
+license: MIT
+---
+
+# Building Animations in Expo
+
+This skill was created in collaboration with [Emil Kowalski](https://github.com/emilkowalski) and can also be found in the [emilkowalski/skills](https://github.com/emilkowalski/skills) repository, along with other useful animation skills.
+
+A construction skill for React Native. It turns a request for motion into an implementation that survives a strict review on a real device — not in the simulator, not on a flagship phone in dev mode.
+
+Mobile changes three things about animation, and everything in this skill follows from them:
+
+1. **There is no hover.** Every affordance the web puts in hover has to live in press, position, or nothing.
+2. **There are two runtimes.** Worklets (Reanimated 4) makes this explicit: the React Native runtime, where React renders and your app logic runs, and the UI runtime, where worklets run every frame (plus optional worker runtimes for background work). An animation that touches the RN runtime stutters the moment the app does anything else. The whole craft is keeping motion on the UI runtime.
+3. **The user's finger is on the element.** Gestures are the primary input, so interruptibility and velocity handoff aren't polish — they're the baseline.
+
+## Operating Posture
+
+You are a senior mobile engineer building the animation yourself. Make the call, state the reasoning in one line, write the code. Never present motion options as a menu.
+
+Two failure modes, and the first is worse:
+
+1. **Animating something that shouldn't animate.** The gate below exists to produce zero lines of code sometimes.
+2. **Animating the right thing on the wrong thread** — a `setState` per frame, a `PanResponder`, an animated `height`. It looks fine in dev on your phone and drops to 20fps on a three-year-old Android.
+
+## Hard Rules
+
+1. **Run the sequence in order.** Steps 1 and 2 gate everything.
+2. **Reanimated, not core `Animated`.** Core `Animated` can't be driven by a gesture without crossing the bridge, and `useNativeDriver` refuses anything but transform and opacity anyway. Reanimated worklets run on the UI thread and keep running while JS is busy.
+3. **No approximated values.** Curves and spring configs come from the tables below.
+4. **Reduced motion ships with the animation**, not as a follow-up.
+5. **Feel is judged on a release build on the slowest device you support.** Nothing else counts as verified.
+
+## The Build Sequence
+
+### 1. Should this animate at all?
+
+| Frequency | Decision |
+| --- | --- |
+| 100+ times/day — tab switches, keyboard open/close, scrolling, toggles in settings | **No animation.** Platform default or nothing. Stop here. |
+| Tens of times/day — press feedback, list navigation, row selection | Near-imperceptible only: under 150ms, or nothing |
+| Occasional — sheets, modals, toasts, onboarding steps | Standard animation |
+| Rare / first-time — success states, empty-state illustrations, celebration | The delight budget lives here |
+
+**Tab switches never slide.** Tabs are peers, not a hierarchy — sliding implies depth that isn't there, and the user pays for it dozens of times a session. `animation: 'none'`.
+
+If the request fails this gate, say so and don't write it.
+
+### 2. What is the purpose?
+
+Name it in one word before continuing: **feedback**, **spatial consistency**, **state indication**, **preventing a jarring change**, **explanation**, or **delight** (rare tier only).
+
+Can't name it? Don't build it.
+
+### 3. Pick the tool — cheapest that works
+
+Walk down; stop at the first that fits.
+
+| Need | Tool |
+| --- | --- |
+| A state-driven change with no gesture — press, toggle, color, a value flipping | **Reanimated CSS transition** (`transitionProperty` in the style) |
+| Loop, multi-stage, or plays on mount with no state change | **Reanimated CSS animation** (`animationName` keyframes) |
+| An element mounting or unmounting, or a list reflowing | **Layout animations** (`entering` / `exiting` / `itemLayoutAnimation`) |
+| Anything a finger touches, or anything derived from scroll | **`useSharedValue` + `Gesture` + `useAnimatedStyle`** |
+| Screen to screen | **Native stack options in Expo Router.** Never hand-roll this |
+| A bottom sheet that is its own screen | **`presentation: 'formSheet'`** — it's a real UISheetPresentationController, free and correct |
+| Tab bar | **`NativeTabs`** (from `expo-router/unstable-native-tabs`) — the platform's real tab bar, its behaviors and transitions included |
+| Context menu, press-and-hold preview | **`Link.Menu` / `Link.Preview`** (Expo Router, iOS-only) — native menus and peek, never rebuilt in JS |
+| Header that collapses into a large title | **`headerLargeTitleEnabled`** on the native stack (iOS-only; `headerLargeTitle` is deprecated) — not a scroll worklet |
+| Pull to refresh | **`RefreshControl`** — hand-roll only when it's a signature interaction (see the threshold recipe) |
+| UI that tracks the keyboard | **`react-native-keyboard-controller`** — the keyboard's real position, frame by frame, on the UI thread |
+| Vector illustration, celebration, empty state | **Lottie** — for illustration only, never for UI state |
+| A huge animated scene, freeform drawing | **`@shopify/react-native-skia`** — a canvas, for when the view hierarchy itself is the bottleneck |
+
+Reach for a shared value only when the value is continuous or interruptible. A press scale is a CSS transition; a drag is a shared value. Using a worklet for a two-state toggle is the mobile equivalent of installing a motion library for a fade.
+
+**Dependencies.** Install with `npx expo install <package>` — it resolves the version that matches the project's SDK, which plain `npm install` won't:
+
+| Need | Package |
+| --- | --- |
+| Animation | `react-native-reanimated` + `react-native-worklets` |
+| Gestures | `react-native-gesture-handler` |
+| Navigation, sheets, native tabs, menus | `expo-router` |
+| Haptics | `expo-haptics` |
+| Keyboard-following UI | `react-native-keyboard-controller` (needs `KeyboardProvider` at the root — see the keyboard recipe) |
+| Illustration, celebration | `lottie-react-native` |
+| Very large animated scenes, custom drawing | `@shopify/react-native-skia` |
+
+### 4. Pick the properties
+
+- **`transform` and `opacity` are free.** Everything else is a layout pass. `width`, `height`, `margin`, `padding`, `flex`, `top`, `left`, `gap` re-run Yoga on every frame for that node *and its siblings*.
+- **The one exception: an absolutely positioned element with no children** — a tab pill, a progress bar fill. It's out of flow, so nothing else re-lays-out, and animating `width` keeps the corner radius that `scaleX` would smear.
+- **Never `scale(0)`.** Start from `scale(0.9–0.97)` + `opacity: 0`. Nothing in the real world appears from nothing.
+- **`transform` is an array and order matters** — `[{ translateY }, { scale }]` scales after moving; reversed, the translate gets scaled too. Keep translate first unless you want the multiplication.
+- **Android shadows are `elevation`, and animating elevation re-renders the shadow every frame.** Animate opacity of a pre-shadowed layer instead.
+- **Never animate `BlurView` intensity.** On Android it re-renders the blur each frame. Crossfade the opacity of a static `BlurView` instead.
+- **Percentages work in `translate`** and are relative to the element's own size — `translateY('100%')` moves a sheet by its own height whatever its content.
+
+### 5. Timing or spring
+
+**If a finger was involved, use a spring.** Springs carry velocity through an interruption; timing curves restart. Everything else uses timing.
+
+Reanimated's spring takes Apple's two designer parameters directly — use this form, not mass/stiffness/damping:
+
+| Interaction | Config |
+| --- | --- |
+| Default settle, no overshoot | `{ duration: 400, dampingRatio: 1 }` |
+| Reposition / snap back after a drag | `{ duration: 400, dampingRatio: 0.8, velocity }` |
+| Sheet, drawer | `{ duration: 300, dampingRatio: 0.8, velocity }` |
+| Must not pass a hard edge | add `overshootClamping: true` |
+
+**Bounce only when the gesture carried momentum.** Overshoot on a menu that faded in feels wrong; overshoot on a card you flicked feels right.
+
+**Easing**, for everything without a finger on it:
+
+| Situation | Easing |
+| --- | --- |
+| Entering or exiting | `ease-out` |
+| Moving / morphing on screen | `ease-in-out` |
+| Constant motion (progress, marquee) | `linear` |
+| Default | `ease-out` |
+
+**Never `ease-in` on UI.** It starts slow, delaying the exact moment the user is watching. Reanimated's built-ins are as weak as CSS's — use these:
+
+```js
+import { Easing } from 'react-native-reanimated';
+
+const EASE_OUT = Easing.bezier(0.23, 1, 0.32, 1);      // strong ease-out for UI
+const EASE_IN_OUT = Easing.bezier(0.77, 0, 0.175, 1);  // on-screen movement
+const EASE_SHEET = Easing.bezier(0.32, 0.72, 0, 1);    // iOS sheet curve
+```
+
+**Duration:**
+
+| Element | Duration |
+| --- | --- |
+| Press feedback | 100–150ms |
+| Toggle, chip, small state change | 150–200ms |
+| Sheet, modal, drawer | spring, ~300ms perceived |
+| Screen transition | the platform default — don't override it |
+
+Mobile UI animations stay under 300ms, same as web. The platform's own transitions are longer (iOS push is 350ms); match the platform for navigation, beat it everywhere else.
+
+### 6. Keep it off the JS thread
+
+This is the mobile-specific craft, and it's where most React Native motion dies.
+
+- **Never `setState` from a gesture or scroll handler.** One React render per frame is the single biggest cause of jank in RN apps. Shared value → `useAnimatedStyle`, and React never re-renders at all.
+- **Never schedule back to the RN runtime inside `onUpdate` or a scroll handler.** `scheduleOnRN(fn, ...args)` from `react-native-worklets` — the Reanimated 4 replacement for the deprecated `runOnJS(fn)(...args)` — queues an RN-runtime call, and in `onUpdate` that's 60–120× per second. It belongs in `onEnd`, or in a `useAnimatedReaction` that fires when a value crosses a threshold.
+- **Never read a shared value during render** (`translateY.get()` in JSX). It's a snapshot that never updates and it silently desyncs. **Never write one during render either** — it fires mid-reconciliation, and a re-render you didn't cause replays the write. Touch shared values only in worklets, handlers, and effects.
+- **Use `.get()` / `.set()`, not `.value`.** Same API, but direct `.value` access is the form the React Compiler can't see through — the Reanimated docs call `get`/`set` the compiler-safe way. `set` also takes a functional update: `sv.set((v) => v + 1)`.
+- **Functions called from a worklet need `'worklet'`** as their first line, or they throw at runtime on device while working fine in the debugger.
+
+### 7. Press, not hover
+
+Every hover affordance from the web has to be redesigned, not ported.
+
+- **Feedback on press-in, commit on press-out.** Waiting for the tap to complete before showing anything feels dead — this is the latency the user actually perceives.
+- **`scale: 0.97` in 100–150ms** on any pressable, `Pressable` + a CSS transition. `scale` takes the label and icons with it, which is what makes it read as physical.
+- **44×44pt minimum touch target** (48dp Android). If the visual is smaller, add `hitSlop` — don't grow the visual.
+- **`pressRetentionOffset`** so a finger drifting a few pixels doesn't cancel a press the user meant.
+- **Android ripple only in a Material-styled app.** In a custom-designed app, the same scale on both platforms is more coherent than a ripple on one.
+
+### 8. Haptics
+
+Mobile has a sense the web doesn't. Use it sparingly and it becomes the thing that makes the app feel expensive; use it everywhere and users turn it off.
+
+| Moment | Call |
+| --- | --- |
+| A value ticks past a step — picker, slider detent, segmented control | `Haptics.selectionAsync()` |
+| Something snaps home, a sheet detent catches, a drag commits | `Haptics.impactAsync(ImpactFeedbackStyle.Light)` |
+| A heavy object lands, a destructive action fires | `Haptics.impactAsync(ImpactFeedbackStyle.Medium)` |
+| Operation succeeded or failed | `Haptics.notificationAsync(NotificationFeedbackType.Success / Error)` |
+
+Three rules, and they're absolute:
+
+- **Same frame as the visual.** A haptic that lags its animation reads as a glitch, not as feedback. Fire it at the causal moment — the detent catching — not when the animation finishes.
+- **One per user action.** Never on scroll, never per frame, never on an entrance animation the user didn't cause.
+- **Never the only feedback.** Haptics are off system-wide for many users, and silent on most Android hardware. The visual has to stand alone.
+
+From a worklet, haptics must be scheduled back to the RN runtime: `scheduleOnRN(Haptics.selectionAsync)`.
+
+### 9. Reduced motion and accessibility
+
+```jsx
+import { useReducedMotion, ReduceMotion, withSpring } from 'react-native-reanimated';
+
+const reduced = useReducedMotion();
+const y = useSharedValue(reduced ? 0 : SHEET_HEIGHT);
+
+// or let each animation decide
+withSpring(0, { duration: 300, dampingRatio: 0.8, reduceMotion: ReduceMotion.System });
+```
+
+Reduced motion means **fewer and gentler**, not zero: keep opacity and color changes that explain a state change, drop translation, scale, parallax and overshoot. Screen transitions become `animation: 'fade'`.
+
+**Text scales.** `allowFontScaling` is on by default, so any height you measured at default type size is wrong at 200%. Never animate to a hardcoded height — measure with `onLayout`, or animate a transform instead.
+
+## Setup that silently breaks motion
+
+Check these first when "the animation just doesn't run":
+
+- Install through Expo so versions match the SDK: `npx expo install react-native-reanimated react-native-worklets`. In an Expo project, `babel-preset-expo` configures the worklets Babel plugin automatically — no `babel.config.js` step. Only a bare RN project without that preset adds the plugin manually, and there it must be last in the list. A missing or misplaced plugin doesn't silently fall back anymore — it throws `Failed to create a worklet` at runtime.
+- `GestureHandlerRootView` must wrap the app, or gestures do nothing with no error.
+- Reanimated 4 requires the New Architecture.
+- **Expo Go is not a performance environment.** Judge feel in a release build; a dev build's JS thread is slow enough to hide exactly the problems you're looking for.
+
+## 120fps
+
+On ProMotion iPhones, third-party animations are capped at 60fps unless `CADisableMinimumFrameDurationOnPhone` is set. Recent Expo SDKs set it by default — confirm it's there, and add it if not:
+
+```json
+{ "expo": { "ios": { "infoPlist": { "CADisableMinimumFrameDurationOnPhone": true } } } }
+```
+
+Then the frame budget is 8ms, not 16. This is also why a UI-thread animation matters more on mobile than it does on web.
+
+## Recipes
+
+For ready-to-build implementations — press feedback, drag-to-dismiss sheet, swipe-to-delete, collapsing header, list entrances, keyboard-synced UI, tab indicator, screen transitions — see [RECIPES.md](RECIPES.md). Load it whenever the request matches one; start from the recipe rather than from a blank file.
+
+## Never Ship
+
+| Never | Instead |
+| --- | --- |
+| `PanResponder` | `Gesture.Pan()` from gesture-handler |
+| `setState` in a gesture or scroll handler | shared value + `useAnimatedStyle` |
+| `runOnJS` (deprecated in Reanimated 4) | `scheduleOnRN` from `react-native-worklets` |
+| `scheduleOnRN` per frame | `onEnd`, or `useAnimatedReaction` at a threshold |
+| Reading or writing a shared value during render | `.get()` / `.set()` in worklets, handlers, effects |
+| Core `Animated` for anything a finger touches | Reanimated |
+| Animating `height` / `width` / `margin` / `flex` / `top` | `transform` + `opacity` (absolute, childless elements exempt) |
+| Animating `BlurView` intensity or Android `elevation` | crossfade a static layer |
+| `entering` on a virtualized list row | animate the container, or `itemLayoutAnimation` |
+| A screen transition rebuilt in JS | native stack `animation` |
+| Sliding between tabs | `animation: 'none'` |
+| `Easing.in(...)` on a UI element | `Easing.bezier(0.23, 1, 0.32, 1)` |
+| `scale(0)` entrance | `scale(0.95)` + `opacity: 0` |
+| Distance-only dismissal threshold | velocity **or** distance — a flick is enough |
+| Hard stop at a boundary | rubber-band resistance |
+| A haptic per frame, or as the only feedback | one per commit, always paired with a visual |
+| Judging feel in Expo Go or the simulator | release build, slowest supported device |
+
+## Output
+
+Write the code. Then, in at most a few lines:
+
+- **The gate result** — frequency tier and named purpose. Say what you rejected and why.
+- **The ingredients** — tool, properties, spring or curve + duration, thread.
+- **What to feel-check on device** — gestures, velocity handoff and haptic timing cannot be judged from code. Name what to try: flick it, interrupt it mid-flight, reverse it, run it on the slowest Android you have.
+
+The code is the deliverable. Don't pad it into a report.
+
+## Tone
+
+Opinionated and brief. When the honest answer is "this shouldn't animate," or "this needs a real device before I can tell you if it's right," give it.
+
+## Submitting Feedback
+If you encounter errors, misleading or outdated information in this skill, report it so Expo can improve:
+```bash
+npx --yes submit-expo-feedback@latest --category skills --subject "expo-animation" "<actionable feedback>"
+```
+Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/expo-animation/agents/openai.yaml
+++ b/plugins/expo/skills/expo-animation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Expo Animation"
+  short_description: "Build polished Expo and React Native animations"
+  default_prompt: "Use $expo-animation to build a polished, accessible animation for this Expo app."

--- a/scripts/sync-animate-expo.ts
+++ b/scripts/sync-animate-expo.ts
@@ -1,0 +1,186 @@
+#!/usr/bin/env bun
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const UPSTREAM_REPOSITORY = "emilkowalski/skills";
+const UPSTREAM_SKILL_DIRECTORY = "skills/animate-expo";
+const LOCAL_SKILL_DIRECTORY = "plugins/expo/skills/expo-animation";
+const DEFAULT_REF = "main";
+const HEADING = "# Building Animations in Expo";
+const ATTRIBUTION =
+  "This skill was created in collaboration with [Emil Kowalski](https://github.com/emilkowalski) and can also be found in the [emilkowalski/skills](https://github.com/emilkowalski/skills) repository, along with other useful animation skills.";
+const FEEDBACK = `## Submitting Feedback
+If you encounter errors, misleading or outdated information in this skill, report it so Expo can improve:
+\`\`\`bash
+npx --yes submit-expo-feedback@latest --category skills --subject "expo-animation" "<actionable feedback>"
+\`\`\`
+Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.`;
+const USAGE = `Usage: bun scripts/sync-animate-expo.ts [options]
+
+Sync Emil Kowalski's animate-expo skill into the Expo repository while preserving
+the Expo-specific skill name, category metadata, attribution, and feedback block.
+
+Options:
+  --check       Report drift without writing files.
+  --ref <ref>   Sync from an upstream branch, tag, or commit (default: main).
+  -h, --help    Show this help.`;
+
+type Options = {
+  check: boolean;
+  ref: string;
+};
+
+function fail(message: string): never {
+  console.error(`${message}\n\n${USAGE}`);
+  process.exit(1);
+}
+
+function parseOptions(args: string[]): Options {
+  let check = false;
+  let ref = DEFAULT_REF;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--check") {
+      check = true;
+    } else if (arg === "--ref") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) fail("--ref requires a value.");
+      ref = value;
+      index += 1;
+    } else if (arg === "-h" || arg === "--help") {
+      console.log(USAGE);
+      process.exit(0);
+    } else {
+      fail(`Unknown option: ${arg}`);
+    }
+  }
+
+  return { check, ref };
+}
+
+function normalize(contents: string): string {
+  return `${contents.replace(/\r\n/g, "\n").trimEnd()}\n`;
+}
+
+async function fetchUpstream(path: string, ref: string): Promise<string> {
+  const url = new URL(
+    `https://api.github.com/repos/${UPSTREAM_REPOSITORY}/contents/${path}`,
+  );
+  url.searchParams.set("ref", ref);
+
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github.raw+json",
+    "User-Agent": "expo-skills-sync",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  const token = process.env.GITHUB_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(
+      `Could not fetch ${path} at ${ref}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return normalize(await response.text());
+}
+
+function extractVersion(path: string): string {
+  if (!existsSync(path)) return "1.0.0";
+  return (
+    readFileSync(path, "utf8").match(/^version:\s*(.+?)\s*$/m)?.[1] ?? "1.0.0"
+  );
+}
+
+function renderSkill(upstream: string, version: string): string {
+  const match = upstream.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match)
+    throw new Error("Upstream SKILL.md does not have valid frontmatter.");
+
+  const description = match[1].match(/^description:\s*(.+?)\s*$/m)?.[1];
+  if (!description)
+    throw new Error("Upstream SKILL.md is missing its description.");
+
+  const body = match[2].trim();
+  if (!body.startsWith(HEADING)) {
+    throw new Error(`Upstream SKILL.md must start with \"${HEADING}\".`);
+  }
+  const bodyAfterHeading = body.slice(HEADING.length).replace(/^\n+/, "");
+
+  return normalize(`---
+name: expo-animation
+description: Framework (OSS). ${description}
+version: ${version}
+license: MIT
+---
+
+${HEADING}
+
+${ATTRIBUTION}
+
+${bodyAfterHeading}
+
+${FEEDBACK}`);
+}
+
+function updateFile(path: string, expected: string, check: boolean): boolean {
+  const current = existsSync(path)
+    ? readFileSync(path, "utf8").replace(/\r\n/g, "\n")
+    : "";
+  if (current === expected) return false;
+
+  if (!check) {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, expected);
+  }
+  return true;
+}
+
+async function main() {
+  const options = parseOptions(process.argv.slice(2));
+  const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const localDirectory = resolve(repositoryRoot, LOCAL_SKILL_DIRECTORY);
+  const localSkillPath = resolve(localDirectory, "SKILL.md");
+
+  const [upstreamSkill, upstreamRecipes, upstreamLicense] = await Promise.all([
+    fetchUpstream(`${UPSTREAM_SKILL_DIRECTORY}/SKILL.md`, options.ref),
+    fetchUpstream(`${UPSTREAM_SKILL_DIRECTORY}/RECIPES.md`, options.ref),
+    fetchUpstream("LICENSE", options.ref),
+  ]);
+
+  const expectedFiles = new Map([
+    [
+      localSkillPath,
+      renderSkill(upstreamSkill, extractVersion(localSkillPath)),
+    ],
+    [resolve(localDirectory, "RECIPES.md"), upstreamRecipes],
+    [resolve(localDirectory, "LICENSE"), upstreamLicense],
+  ]);
+  const changed = [...expectedFiles].filter(([path, expected]) =>
+    updateFile(path, expected, options.check),
+  );
+
+  if (changed.length === 0) {
+    console.log(
+      `expo-animation is up to date with ${UPSTREAM_REPOSITORY}@${options.ref}.`,
+    );
+    return;
+  }
+
+  for (const [path] of changed) {
+    console.log(
+      `${options.check ? "Out of date" : "Updated"}: ${path.slice(repositoryRoot.length + 1)}`,
+    );
+  }
+  if (options.check) process.exit(1);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -8,6 +8,7 @@
       "skills": [
         "expo-project-structure",
         "expo-router",
+        "expo-animation",
         "expo-native-ui",
         "expo-design-system",
         "expo-ui",


### PR DESCRIPTION
Emil Kowalski created the `animate-expo` skill (https://github.com/emilkowalski/skills/pull/25) in collaboration with Expo.

I want to copy the skill in our skills so our users can create beautiful animations in expo.

This PR adds the `expo-animation` skill with attribution.
It also adds `scripts/sync-animate-expo.ts` to pull future upstream changes while preserving Expo-specific metadata, attribution, and feedback instructions.

Bumps the Expo plugin manifests to 1.11.0.