### PR TITLE
[eas-app-stores] fix invalid submit job examples

### DIFF
--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.11.0",
+  "version": "1.11.4",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.11.0",
+  "version": "1.11.4",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.11.0",
+  "version": "1.11.4",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/skills/eas-app-stores/references/ios-app-store.md
+++ b/plugins/expo/skills/eas-app-stores/references/ios-app-store.md
@@ -357,7 +357,7 @@ jobs:
     type: submit
     needs: [build]
     params:
-      platform: ios
+      build_id: ${{ needs.build.outputs.build_id }}
       profile: production
 ```
 

--- a/plugins/expo/skills/eas-app-stores/references/workflows.md
+++ b/plugins/expo/skills/eas-app-stores/references/workflows.md
@@ -35,30 +35,30 @@ on:
     tags: ['v*']
 
 jobs:
-  build-ios:
+  build_ios:
     type: build
     params:
       platform: ios
       profile: production
 
-  build-android:
+  build_android:
     type: build
     params:
       platform: android
       profile: production
 
-  submit-ios:
+  submit_ios:
     type: submit
-    needs: [build-ios]
+    needs: [build_ios]
     params:
-      platform: ios
+      build_id: ${{ needs.build_ios.outputs.build_id }}
       profile: production
 
-  submit-android:
+  submit_android:
     type: submit
-    needs: [build-android]
+    needs: [build_android]
     params:
-      platform: android
+      build_id: ${{ needs.build_android.outputs.build_id }}
       profile: production
 ```
 


### PR DESCRIPTION
# Why

The `submit` job examples in the `eas-app-stores` skill use `platform:` in
`params`, but the EAS Workflows schema requires `build_id` for submit jobs and
does not allow `platform`.

Expo's published workflow documentation already uses `build_id` wired from the
preceding build job. This brings the skill references in line with that syntax.

# How

- Updated both submit jobs in `references/workflows.md` to use
  `build_id: ${{ needs.<build_job>.outputs.build_id }}`.
- Updated the submit job in `references/ios-app-store.md` the same way.
- Renamed the Production Release job IDs to underscores so the new
  `needs.<job_id>.outputs.build_id` expressions follow the documented EAS
  Workflows job-ID syntax.
- Bumped the Expo plugin version to `1.11.4`.

# Test Plan

- Validated both corrected workflow examples against the current EAS Workflows
  schema.
- Confirmed the original `platform:` form fails validation while the corrected
  `build_id` form passes.
- Ran `bun scripts/check-skill-limits.ts`.
- Ran `bun scripts/check-plugin-version-bump.ts origin/main`.
