### PR TITLE
[plugin] add Grok Build manifest and bump to 1.11.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ plugins/
       plugin.json           # Codex plugin manifest
     .cursor-plugin/
       plugin.json           # Cursor plugin manifest
+    .grok-plugin/
+      plugin.json           # Grok Build plugin manifest
     .mcp.json               # Claude Code and Codex MCP server configuration
     mcp.json                # Cursor MCP server configuration
     skills/
@@ -201,7 +203,7 @@ Follow the full guide in `CONTRIBUTING.md`. In short:
 3. Add focused reference files under `references/` when the skill needs more detail than belongs in the main `SKILL.md`, scripts under `scripts/` only for reusable logic, and `agents/openai.yaml` for Codex triggering.
 4. Add the canonical feedback block with `bun scripts/check-skill-limits.ts --fix-feedback`; CI verifies that its subject matches the skill name.
 5. Register the skill in every catalog: `skills.sh.json`, `plugins/expo/README.md`, `plugins/expo/skills/README.md`, and the root `README.md`.
-6. Bump the version in all three plugin manifests together with `bun scripts/check-plugin-version-bump.ts --set-version <version>` (they must match and be greater than main; CI-enforced).
+6. Bump the version in all four plugin manifests together with `bun scripts/check-plugin-version-bump.ts --set-version <version>` (they must match and be greater than main; CI-enforced).
 7. Keep the skill under the existing `expo` plugin unless there is a clear distribution reason to create a new plugin.
 
 ## Testing Plugins
@@ -224,6 +226,7 @@ python3 -m json.tool .cursor-plugin/marketplace.json >/dev/null
 python3 -m json.tool plugins/expo/.claude-plugin/plugin.json >/dev/null
 python3 -m json.tool plugins/expo/.codex-plugin/plugin.json >/dev/null
 python3 -m json.tool plugins/expo/.cursor-plugin/plugin.json >/dev/null
+python3 -m json.tool plugins/expo/.grok-plugin/plugin.json >/dev/null
 python3 -m json.tool plugins/expo/.mcp.json >/dev/null
 python3 -m json.tool plugins/expo/mcp.json >/dev/null
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,14 +115,15 @@ CI fails if the block is missing, has drifted, or names the wrong skill.
 
 ### 10. Bump the plugin version
 
-Bump `version` in **all three** manifests together - they must match each other and be greater
+Bump `version` in **all four** manifests together - they must match each other and be greater
 than `main`. CI enforces this.
 
 - `plugins/expo/.claude-plugin/plugin.json`
 - `plugins/expo/.codex-plugin/plugin.json`
 - `plugins/expo/.cursor-plugin/plugin.json`
+- `plugins/expo/.grok-plugin/plugin.json`
 
-The check script writes all three for you, rejecting a version that is not valid semver or is not
+The check script writes all four for you, rejecting a version that is not valid semver or is not
 greater than the base ref:
 
 ```bash

--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "expo",
   "displayName": "Expo",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.grok-plugin/plugin.json
+++ b/plugins/expo/.grok-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "expo",
+  "version": "1.11.1",
+  "description": "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web.",
+  "author": {
+    "name": "Expo Team",
+    "email": "support@expo.dev",
+    "url": "https://expo.dev"
+  },
+  "homepage": "https://docs.expo.dev/skills/",
+  "repository": "https://github.com/expo/skills/tree/main/plugins/expo",
+  "license": "MIT"
+}

--- a/scripts/check-plugin-version-bump.test.ts
+++ b/scripts/check-plugin-version-bump.test.ts
@@ -3,7 +3,7 @@
 //
 // Usage: bun test scripts/check-plugin-version-bump.test.ts
 //
-// The --set-version cases write to the three plugin manifests. They are backed
+// The --set-version cases write to the plugin manifests. They are backed
 // up before the suite and restored before every test and after the run, so each
 // test starts from a pristine copy and any uncommitted edits you already had in
 // those files survive the run.
@@ -23,6 +23,7 @@ const manifests = [
   "plugins/expo/.claude-plugin/plugin.json",
   "plugins/expo/.codex-plugin/plugin.json",
   "plugins/expo/.cursor-plugin/plugin.json",
+  "plugins/expo/.grok-plugin/plugin.json",
 ];
 
 process.chdir(join(import.meta.dir, ".."));
@@ -190,11 +191,11 @@ describe("base-ref comparison", () => {
 });
 
 describe("--set-version", () => {
-  test("writes the version to all three manifests", () => {
+  test("writes the version to all plugin manifests", () => {
     const { exitCode, output } = runCheck("HEAD", "--set-version", nextVersion);
 
     expect(exitCode).toBe(0);
-    expect(output).toContain(`All three plugin manifests are now at ${nextVersion}`);
+    expect(output).toContain(`All ${manifests.length} plugin manifests are now at ${nextVersion}`);
 
     for (const manifest of manifests) {
       expect(versionOf(manifest)).toBe(nextVersion);
@@ -221,7 +222,7 @@ describe("--set-version", () => {
     const { exitCode, output } = runCheck("HEAD", `--set-version=${laterVersion}`);
 
     expect(exitCode).toBe(0);
-    expect(output).toContain(`All three plugin manifests are now at ${laterVersion}`);
+    expect(output).toContain(`All ${manifests.length} plugin manifests are now at ${laterVersion}`);
   });
 });
 

--- a/scripts/check-plugin-version-bump.ts
+++ b/scripts/check-plugin-version-bump.ts
@@ -28,6 +28,10 @@ const pluginManifests: PluginManifest[] = [
     label: "Cursor",
     path: "plugins/expo/.cursor-plugin/plugin.json",
   },
+  {
+    label: "Grok",
+    path: "plugins/expo/.grok-plugin/plugin.json",
+  },
 ];
 
 const versionedPluginPaths = [
@@ -35,6 +39,7 @@ const versionedPluginPaths = [
   "plugins/expo/.claude-plugin/plugin.json",
   "plugins/expo/.codex-plugin/plugin.json",
   "plugins/expo/.cursor-plugin/plugin.json",
+  "plugins/expo/.grok-plugin/plugin.json",
   "plugins/expo/.mcp.json",
   "plugins/expo/mcp.json",
 ];
@@ -42,8 +47,8 @@ const versionedPluginPaths = [
 const USAGE = `Usage: bun scripts/check-plugin-version-bump.ts [base-ref] [options]
 
 Guards the rule that CI enforces: when any versioned Expo plugin file changes,
-the Claude, Codex, and Cursor plugin manifests must all be bumped together to
-the same version, and that version must be greater than the one on the base ref.
+the Claude, Codex, Cursor, and Grok plugin manifests must all be bumped together
+to the same version, and that version must be greater than the one on the base ref.
 
 Versioned paths:
 ${versionedPluginPaths.map((path) => `  ${path}`).join("\n")}
@@ -55,7 +60,7 @@ Arguments:
   base-ref              Git ref to compare against (default: origin/main).
 
 Options:
-  --set-version <ver>   Write <ver> as the version in all three manifests
+  --set-version <ver>   Write <ver> as the version in all plugin manifests
                         instead of running the check. Must be valid semver and
                         greater than the version on the base ref.
   -h, --help            Print this help and exit.
@@ -216,7 +221,7 @@ function setVersions(nextVersion: string): never {
     console.log(`Updated ${update.label}: ${update.currentVersion} → ${nextVersion} (${update.path})`);
   }
 
-  console.log(`\nAll three plugin manifests are now at ${nextVersion}.`);
+  console.log(`\nAll ${pluginManifests.length} plugin manifests are now at ${nextVersion}.`);
   process.exit(0);
 }
 
@@ -256,9 +261,7 @@ const currentVersions = new Set(rows.map((row) => row.currentVersion));
 const baseVersions = new Set(rows.map((row) => row.baseVersion));
 
 for (const row of rows) {
-  if (row.baseVersion === undefined) {
-    errors.push(`${row.label} manifest is missing or has no version on main (${row.path}).`);
-  } else if (!isSemver(row.baseVersion)) {
+  if (row.baseVersion !== undefined && !isSemver(row.baseVersion)) {
     errors.push(`${row.label} has an invalid semver version on main: ${formatVersion(row.baseVersion)}`);
   }
 
@@ -269,18 +272,22 @@ for (const row of rows) {
   }
 }
 
-if (baseVersions.size !== 1) {
-  errors.push("The Claude, Codex, and Cursor plugin versions on main are not in sync.");
+const presentBaseVersions = [...baseVersions].filter(isSemver);
+
+if (new Set(presentBaseVersions).size > 1) {
+  errors.push("The Claude, Codex, Cursor, and Grok plugin versions on main are not in sync.");
 }
 
 if (currentVersions.size !== 1) {
-  errors.push("The Claude, Codex, and Cursor plugin versions in this PR must match.");
+  errors.push("The Claude, Codex, Cursor, and Grok plugin versions in this PR must match.");
 }
 
 if (errors.length === 0) {
+  const sharedBase = presentBaseVersions[0];
   for (const row of rows) {
-    if (semver.order(row.currentVersion as string, row.baseVersion as string) <= 0) {
-      errors.push(`${row.label} version must be greater than main (${formatVersion(row.baseVersion)}).`);
+    const base = isSemver(row.baseVersion) ? row.baseVersion : sharedBase;
+    if (base === undefined || semver.order(row.currentVersion as string, base) <= 0) {
+      errors.push(`${row.label} version must be greater than main (${formatVersion(base)}).`);
     }
   }
 }
@@ -291,7 +298,7 @@ const markdown = [
   "",
   errors.length === 0
     ? "Passed. Versioned Expo plugin files changed and all plugin manifests were bumped together."
-    : "Failed. Versioned Expo plugin files changed, so the Claude, Codex, and Cursor plugin manifests must all be bumped together.",
+    : "Failed. Versioned Expo plugin files changed, so the Claude, Codex, Cursor, and Grok plugin manifests must all be bumped together.",
   "",
   formatVersionRows(rows),
   "",


### PR DESCRIPTION
## Why

Grok Build's marketplace reads `.grok-plugin/plugin.json` first, then falls back to `.claude-plugin/plugin.json`. Add an official Grok manifest so listing/version bumps are not coupled to Claude by accident.

## How

- Add `plugins/expo/.grok-plugin/plugin.json` with the Grok listing description.
- Include it in `check-plugin-version-bump.ts` (and tests, CONTRIBUTING, AGENTS.md). New manifests missing on `main` are allowed so this first PR does not fail the version check.
- Bump Claude, Codex, Cursor, and Grok together: **1.11.0 → 1.11.1**.

## Test Plan

```
bun test scripts/check-plugin-version-bump.test.ts
python3 -m json.tool plugins/expo/.grok-plugin/plugin.json
```

20 tests passed locally.