### PR TITLE
[plugin] Cursor: set logo, rename to Expo, align description

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -10,9 +10,9 @@
   },
   "plugins": [
     {
-      "name": "expo",
+      "name": "Expo",
       "source": "./plugins/expo",
-      "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps."
+      "description": "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web."
     },
     {
       "name": "expo-experiments",

--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -21,6 +21,7 @@
     "native-modules",
     "mcp"
   ],
+  "logo": "./assets/expo.png",
   "skills": "./skills/",
   "mcpServers": "./mcp.json"
 }

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
-  "name": "expo",
+  "name": "Expo",
   "displayName": "Expo",
-  "version": "1.11.1",
-  "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
+  "version": "1.11.2",
+  "description": "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web.",
   "author": {
     "name": "Expo Team",
     "email": "support@expo.dev"

--- a/plugins/expo/.grok-plugin/plugin.json
+++ b/plugins/expo/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web.",
   "author": {
     "name": "Expo Team",


### PR DESCRIPTION
# Why

The Cursor plugin manifest was missing the `logo` field (Codex already points at `./assets/expo.png` via `interface.logo`), displayed the lowercase `expo` name, and carried an older description than the Grok manifest.

# How

- Added `"logo": "./assets/expo.png"` to `.cursor-plugin/plugin.json`. Cursor's plugins reference accepts a relative repo path resolved via raw.githubusercontent.com; no format or dimension requirements are documented, and the existing 2048×2048 PNG (10 KB) is reused so all clients share one asset.
- Renamed the Cursor plugin to `Expo` in both `.cursor-plugin/plugin.json` and the root `.cursor-plugin/marketplace.json` entry that references it.
- Aligned the description in both files with the Grok manifest: "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web."
- Bumped all four client manifests to 1.11.2, as required by the plugin version check.

# Test Plan

- `bun test scripts/check-plugin-version-bump.test.ts` — 20 pass, 0 fail.
- `bun scripts/check-plugin-version-bump.ts origin/main` — all four manifests at 1.11.2, no required fixes.
- Both edited JSON files validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)