### PR TITLE
[ENG-25820][skills][eas-workflows] fix fetch.js silently no-op on Node

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js 20
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,6 +27,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Node.js 20
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "20"
+
+      - name: Test EAS workflow fetch helper
+        run: node --test plugins/expo/skills/eas-workflows/scripts/fetch.test.js
+
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 

--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Expo",
   "displayName": "Expo",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "description": "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.grok-plugin/plugin.json
+++ b/plugins/expo/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "description": "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/skills/eas-workflows/SKILL.md
+++ b/plugins/expo/skills/eas-workflows/SKILL.md
@@ -16,9 +16,11 @@ Help developers write and edit EAS CI/CD workflow YAML files.
 
 Fetch these resources before generating or editing workflow files, or when answering syntax questions. First resolve this skill's directory, then use the fetch script in its `scripts/` directory. It is implemented using Node.js and caches responses using ETags for efficiency:
 
+Run the helper with Node.js. If it fails or prints no content, stop instead of continuing from memory.
+
 ```bash
 # Fetch resources
-node <skill-dir>/scripts/fetch.js <url>
+node "<skill-dir>/scripts/fetch.js" "<url>"
 ```
 
 1. **JSON Schema** — https://api.expo.dev/v2/workflows/schema

--- a/plugins/expo/skills/eas-workflows/scripts/fetch.js
+++ b/plugins/expo/skills/eas-workflows/scripts/fetch.js
@@ -4,6 +4,7 @@ import { createHash } from 'node:crypto';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import process from 'node:process';
+import { pathToFileURL } from 'node:url';
 
 const CACHE_DIRECTORY = resolve(import.meta.dirname, '.cache');
 const DEFAULT_TTL_SECONDS = 15 * 60; // 15 minutes
@@ -92,7 +93,8 @@ function parseMaxAge(cacheControl) {
   return match ? parseInt(match[1], 10) : null;
 }
 
-if (import.meta.main) {
+// Node 20 and Node releases before 22.18 do not provide import.meta.main.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const url = process.argv[2];
 
   if (!url || url === '--help' || url === '-h') {

--- a/plugins/expo/skills/eas-workflows/scripts/fetch.js
+++ b/plugins/expo/skills/eas-workflows/scripts/fetch.js
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 
 import { createHash } from 'node:crypto';
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, realpath } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import process from 'node:process';
-import { pathToFileURL } from 'node:url';
 
 const CACHE_DIRECTORY = resolve(import.meta.dirname, '.cache');
 const DEFAULT_TTL_SECONDS = 15 * 60; // 15 minutes
@@ -93,8 +92,13 @@ function parseMaxAge(cacheControl) {
   return match ? parseInt(match[1], 10) : null;
 }
 
-// Node 20 and Node releases before 22.18 do not provide import.meta.main.
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+// Older Node versions need a real-path comparison so symlinked installs still run.
+const isMain = import.meta.main ?? (
+  process.argv[1] &&
+  (await realpath(process.argv[1]).catch(() => null)) === (await realpath(new URL(import.meta.url)))
+);
+
+if (isMain) {
   const url = process.argv[2];
 
   if (!url || url === '--help' || url === '-h') {

--- a/plugins/expo/skills/eas-workflows/scripts/fetch.test.js
+++ b/plugins/expo/skills/eas-workflows/scripts/fetch.test.js
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { copyFile, mkdir, mkdtemp, rm, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
@@ -13,10 +16,43 @@ test('runs the command-line interface directly with Node', () => {
   assert.match(result.stdout, /Usage: fetch <url>/);
 });
 
+test('fetches content through a symlinked skill directory', async (t) => {
+  const fixtureDirectory = await mkdtemp(join(tmpdir(), 'eas-workflows-fetch-'));
+  t.after(() => rm(fixtureDirectory, { recursive: true, force: true }));
+
+  const skillDirectory = join(fixtureDirectory, 'original skill');
+  await mkdir(skillDirectory);
+  await copyFile(scriptPath, join(skillDirectory, 'fetch.js'));
+  await copyFile(new URL('./package.json', import.meta.url), join(skillDirectory, 'package.json'));
+
+  const installedDirectory = join(fixtureDirectory, 'installed skill');
+  await symlink(skillDirectory, installedDirectory, process.platform === 'win32' ? 'junction' : 'dir');
+
+  const result = spawnSync(
+    process.execPath,
+    [join(installedDirectory, 'fetch.js'), 'data:text/plain,workflow-schema'],
+    { encoding: 'utf8' }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, 'workflow-schema\n');
+});
+
 test('does not execute the command-line interface when imported', () => {
   const result = spawnSync(
     process.execPath,
     ['--input-type=module', '--eval', `await import(${JSON.stringify(scriptUrl.href)})`],
+    { encoding: 'utf8' }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, '');
+});
+
+test('can be imported when an eval argument is not a file', () => {
+  const result = spawnSync(
+    process.execPath,
+    ['--input-type=module', '--eval', `await import(${JSON.stringify(scriptUrl.href)})`, 'not-an-entrypoint'],
     { encoding: 'utf8' }
   );
 

--- a/plugins/expo/skills/eas-workflows/scripts/fetch.test.js
+++ b/plugins/expo/skills/eas-workflows/scripts/fetch.test.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptUrl = new URL('./fetch.js', import.meta.url);
+const scriptPath = fileURLToPath(scriptUrl);
+
+test('runs the command-line interface directly with Node', () => {
+  const result = spawnSync(process.execPath, [scriptPath, '--help'], { encoding: 'utf8' });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Usage: fetch <url>/);
+});
+
+test('does not execute the command-line interface when imported', () => {
+  const result = spawnSync(
+    process.execPath,
+    ['--input-type=module', '--eval', `await import(${JSON.stringify(scriptUrl.href)})`],
+    { encoding: 'utf8' }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, '');
+});


### PR DESCRIPTION
🤖 Agent PR for ENG-25820 from Expo CLI feedback.

Fixes ENG-25820

## Why

Expo Feedback grouped six reports from developers and agents using the `eas-workflows` skill on Node 20–23. The skill documented this command:

```sh
node <skill-dir>/scripts/fetch.js <url>
```

However, `fetch.js` used `if (import.meta.main)` to enter its CLI. On affected Node versions that property is `undefined`, so the helper ran nothing, printed nothing, and still exited 0. Agents therefore interpreted a silent no-op as a successful fetch and could continue without the current workflow schema.

The reports also mentioned the same bug in `validate.js`. That validator was removed by #149 in favor of authoritative EAS CLI validation, but `fetch.js` remained broken. This PR completes the fix for ENG-25820.

## What changed

- prefer native `import.meta.main` when available, with a symlink-aware real-path comparison on older Node versions
- tell agents to stop when the Node helper fails or produces no content
- quote the documented script path and URL
- add regression tests for direct CLI execution, actual fetching through symlinked skill directories (including paths with spaces), and safe imports with or without non-file eval arguments
- run that regression under Node 20 in the existing repository check job

## Fix layer

This is a bug in the helper shipped by `expo/skills`, not in the Expo SDK, EAS CLI, or the EAS Workflows service. Fixing the distributed skill script is therefore the complete source-level fix.

## Verification

- all six linked feedback conversations reviewed
- the symlink regression failed before the fix (exit 0 with empty output) and passes afterward
- all four helper tests pass locally on Node 20.19.0, 20.20.2, 22.17.0, 22.23.2, 24.20.0, and 26.0.0
- symlinked CLI invocation also passes with `--preserve-symlinks-main` on Node 20.20.2 and 26.0.0
- skill, plugin manifest, routing, JSON, and workflow YAML checks pass
