### PR TITLE
[skills][expo-ui] ship list-components as .cjs so it runs in ESM projects

### DIFF
--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.12.0",
+  "version": "1.12.2",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.12.0",
+  "version": "1.12.2",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Expo",
   "displayName": "Expo",
-  "version": "1.12.0",
+  "version": "1.12.2",
   "description": "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.grok-plugin/plugin.json
+++ b/plugins/expo/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.12.0",
+  "version": "1.12.2",
   "description": "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/skills/expo-ui/SKILL.md
+++ b/plugins/expo/skills/expo-ui/SKILL.md
@@ -3,7 +3,7 @@ name: expo-ui
 description: "Framework (OSS). Build native UI with the @expo/ui package: real SwiftUI on iOS and Jetpack Compose on Android. Default to @expo/ui for sheets (BottomSheet), pickers, sliders, toggles, menus, and grouped-form sections — do NOT reach for Reanimated, @gorhom/bottom-sheet, or RN built-in Picker/Switch; use @expo/ui instead. Fall back to RN built-ins only when @expo/ui is missing the component. NOTE: @expo/ui List renders native grouped rows like an iOS Settings screen — it is NOT a virtualized list; use FlatList/FlashList for large datasets. Covers universal components (Host, Column, Row, Button, Text, List, BottomSheet, FieldGroup, Switch, Slider, Picker, Menu), drop-in replacements for RN community libraries, and platform-specific SwiftUI/Jetpack Compose trees. Not for Expo Router navigation, Reanimated, or data fetching."
 version: 1.0.0
 license: MIT
-allowed-tools: "Bash(node *expo-ui/scripts/list-components.js *)"
+allowed-tools: "Bash(node *expo-ui/scripts/list-components.cjs *)"
 ---
 
 # Expo UI (`@expo/ui`)

--- a/plugins/expo/skills/expo-ui/references/jetpack-compose.md
+++ b/plugins/expo/skills/expo-ui/references/jetpack-compose.md
@@ -35,8 +35,8 @@ const ComposeList = Platform.OS === 'android' ? require('../components/ProductLi
 - Components are imported from `@expo/ui/jetpack-compose`, modifiers from `@expo/ui/jetpack-compose/modifiers`.
 - **Before writing any code, run the list-components script** to get the exact components and modifiers available in the installed version:
   ```bash
-  node <skill-root>/scripts/list-components.js <project-path>          # names only (compact)
-  node <skill-root>/scripts/list-components.js <project-path> --docs   # with one-line descriptions
+  node <skill-root>/scripts/list-components.cjs <project-path>          # names only (compact)
+  node <skill-root>/scripts/list-components.cjs <project-path> --docs   # with one-line descriptions
   ```
   (`<skill-root>` is the directory containing this `references/` folder.)
 - **Always read the `.d.ts` type files** to confirm prop shapes and signatures — read the relevant `{ComponentName}/index.d.ts` from the installed `@expo/ui/jetpack-compose` package in `node_modules`. This is the most reliable source of truth.

--- a/plugins/expo/skills/expo-ui/references/swift-ui.md
+++ b/plugins/expo/skills/expo-ui/references/swift-ui.md
@@ -38,8 +38,8 @@ Or more simply, put the `Platform.OS` guard and the SwiftUI import in the same r
 - Components are imported from `@expo/ui/swift-ui`, modifiers from `@expo/ui/swift-ui/modifiers`.
 - **Before writing any code, run the list-components script** to get the exact components and modifiers available in the installed version:
   ```bash
-  node <skill-root>/scripts/list-components.js <project-path>          # names only (compact)
-  node <skill-root>/scripts/list-components.js <project-path> --docs   # with one-line descriptions
+  node <skill-root>/scripts/list-components.cjs <project-path>          # names only (compact)
+  node <skill-root>/scripts/list-components.cjs <project-path> --docs   # with one-line descriptions
   ```
   (`<skill-root>` is the directory containing this `references/` folder.)
 - **The installed package's TypeScript types (`.d.ts`) are the most reliable source of truth** for prop shapes and signatures — read the relevant `{Component}/index.d.ts` from the installed `@expo/ui/swift-ui` package in `node_modules`. Use the docs below as the human-readable reference.

--- a/plugins/expo/skills/expo-ui/scripts/list-components.cjs
+++ b/plugins/expo/skills/expo-ui/scripts/list-components.cjs
@@ -3,7 +3,7 @@
  * List available @expo/ui components and modifiers installed in a project.
  *
  * Usage:
- *   node list-components.js <project-path> [--docs]
+ *   node list-components.cjs <project-path> [--docs]
  *
  *   --docs  Include a one-line JSDoc description per modifier.
  *           Omit (default) for a compact names-only list that consumes fewer tokens.
@@ -20,7 +20,7 @@ const projectPath = process.argv[2];
 const withDocs = process.argv.includes('--docs');
 
 if (!projectPath) {
-  console.error('Usage: node list-components.js <project-path> [--docs]');
+  console.error('Usage: node list-components.cjs <project-path> [--docs]');
   process.exit(1);
 }
 


### PR DESCRIPTION
Fixes ENG-26069

## Problem

`plugins/expo/skills/expo-ui/scripts/list-components.js` uses `require()`, and the
`expo-ui/scripts/` directory pins no module type. Node resolves the nearest
`package.json` by walking up from the script, so when the skill is installed into a
project whose `package.json` has `"type": "module"`, Node treats the script as ESM
and throws `require is not defined`.

This repository's own root `package.json` sets no `type`, so the script works here
and fails only once installed into an ESM project — which is why it reached users
rather than CI.

## Reproduction

```
$ echo '{"name":"x","type":"module"}' > package.json
$ node list-components.js <project-path>
const fs = require('fs');
           ^
ReferenceError: require is not defined in ES module scope
```

The identical file renamed to `.cjs` runs correctly and reaches its real logic.

## Fix

Rename the script to `.cjs`. The extension pins CommonJS regardless of any
`package.json` above it, which is already how this repository ships CommonJS skill
scripts — `expo-skill-feedback/scripts/` uses `skill-event.cjs`, `telemetry.cjs`,
and `telemetry_common.cjs`.

Considered and rejected: adding `expo-ui/scripts/package.json` with
`"type": "commonjs"`. It works, but it plants a `package.json` inside a
user-installed plugin directory where workspace globs may pick it up. The `.cjs`
extension carries no such risk.

All six references updated: the `allowed-tools` pattern in `SKILL.md`, the usage
lines in `references/jetpack-compose.md` and `references/swift-ui.md`, and the two
usage strings inside the script itself.

## Verification

- Reproduced the failure with `type: module`, confirmed `.cjs` resolves it
- No `list-components.js` references remain in the repository
- Local CI: skill requirements, plugin version bump, expo-overview routing, and the
  version-bump test suite all pass; manifests bumped 1.12.1 → 1.12.2 together

## Evidence

One linked report in ENG-26069.