### PR TITLE
fix(expo-ui): avoid RN TextInput in SwiftUI host (ENG-26203)

### DIFF
--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Expo",
   "displayName": "Expo",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.grok-plugin/plugin.json
+++ b/plugins/expo/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/skills/expo-ui/references/swift-ui.md
+++ b/plugins/expo/skills/expo-ui/references/swift-ui.md
@@ -63,6 +63,25 @@ import { Pressable } from "react-native";
 </Host>;
 ```
 
+### Keep text input native to the SwiftUI tree
+
+Prefer native SwiftUI controls inside a SwiftUI tree when Expo UI provides them. In particular,
+**do not put React Native's `TextInput` inside `RNHostView`**. On SDK 57.0.13, that combination can
+make labels on subsequent SwiftUI `Picker` and `Button` siblings invisible even though their layout
+and tap targets remain intact. Use `TextField` and `useNativeState` from `@expo/ui/swift-ui` instead:
+
+```tsx
+import { TextField, useNativeState } from '@expo/ui/swift-ui';
+
+function NameField() {
+  const text = useNativeState('');
+  return <TextField text={text} placeholder="Name" />;
+}
+```
+
+For cross-platform input, use the universal `TextInput` from `@expo/ui`. See the
+[SwiftUI TextField documentation](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/textfield/).
+
 - If a required modifier or View is missing in Expo UI, it can be extended via a local Expo module. See: https://docs.expo.dev/guides/expo-ui-swift-ui/extending/index.md. Confirm with the user before extending.
 
 ## useNativeState


### PR DESCRIPTION
## Summary

- warn against embedding React Native `TextInput` in a SwiftUI `RNHostView`
- document the SDK 57.0.13 sibling-label rendering failure and the native `TextField` + `useNativeState` replacement
- point cross-platform forms to universal `@expo/ui` `TextInput`
- bump all Expo plugin manifests to 1.12.1

## Validation

- `bun test scripts/check-plugin-version-bump.test.ts` (20 passed)
- `bun scripts/check-skill-limits.ts`
- `bun scripts/check-plugin-version-bump.ts origin/main`
- `bun scripts/check-overview-routing.ts`
- `claude plugin validate .`
- `claude plugin validate ./plugins/expo`
- clean-context forward test selected `TextField` and avoided `RNHostView`

Fixes ENG-26203