### PR TITLE
ENG-25791: keep expo-constants with Expo Router

### DIFF
--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Expo",
   "displayName": "Expo",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "description": "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.grok-plugin/plugin.json
+++ b/plugins/expo/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "description": "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/skills/expo-upgrade/SKILL.md
+++ b/plugins/expo/skills/expo-upgrade/SKILL.md
@@ -81,7 +81,9 @@ These steps only apply when `ios/` and/or `android/` directories exist in the pr
 - If using Expo SDK 54 or later, ensure react-native-worklets is installed — this is required for react-native-reanimated to work.
 - Enable React Compiler in SDK 54+ by adding `"experiments": { "reactCompiler": true }` to app.json — it's stable and recommended
 - Delete sdkVersion from `app.json` to let Expo manage it automatically
-- Remove implicit packages from `package.json`: `@babel/core`, `babel-preset-expo`, `expo-constants`.
+- Review formerly implicit packages such as `@babel/core`, `babel-preset-expo`, and `expo-constants` individually instead of removing them wholesale. Keep any package that an installed dependency declares as a required peer.
+- Keep `expo-constants` as a direct dependency whenever `expo-router` is installed. Expo Router imports it and declares it as a required peer; relying on a transitive copy can break native autolinking outside Expo Go.
+- After removing any dependency, immediately run `npx expo-doctor` and restore anything it reports as a missing required peer.
 - If the babel.config.js only contains 'babel-preset-expo', delete the file
 - If the metro.config.js only contains expo defaults, delete the file
 


### PR DESCRIPTION
🤖 Agent PR for ENG-25791 from Expo CLI feedback.

## Diagnosis

The published `expo-router@57.0.17` package correctly declares `expo-constants` as a required, non-optional peer dependency. The defect is therefore in the `expo-upgrade` skill layer: its Housekeeping section unconditionally tells agents to remove `expo-constants`.

All 16 linked feedback conversations were audited in full. They independently reproduce the same contradiction across SDK 54, 55, 56, and 57 on macOS, Windows, and Linux. One report also shows `@bugsnag/expo` requiring `expo-constants`, supporting a general required-peer check rather than an Expo Router-only exception.

## Changes

- review formerly implicit packages individually instead of removing them wholesale
- keep `expo-constants` as a direct dependency whenever `expo-router` is installed
- run `npx expo-doctor` immediately after dependency cleanup and restore missing required peers
- bump all Expo plugin manifests from 1.12.3 to 1.12.4

## Validation

- `bun scripts/check-skill-limits.ts`
- `bun scripts/check-plugin-version-bump.ts origin/main`
- `bun test scripts/check-plugin-version-bump.test.ts` (20 passing)
- `bun scripts/check-overview-routing.ts`
- `claude plugin validate ./plugins/expo`
- JSON validation for all four plugin manifests
- `git diff --check origin/main...HEAD`

Fixes ENG-25791