### PR TITLE
[skills] fix Reanimated CSS easing in expo-animation

### DIFF
--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Expo",
   "displayName": "Expo",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.grok-plugin/plugin.json
+++ b/plugins/expo/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/skills/expo-animation/RECIPES.md
+++ b/plugins/expo/skills/expo-animation/RECIPES.md
@@ -89,7 +89,7 @@ function rubberband(overshoot, dimension, constant = 0.55) {
 Every pressable in the app. This passes the frequency gate only because it's near-imperceptible: 120ms and a 3% scale is the ceiling for something touched this often — anything longer or larger belongs to rarer moments, per step 1 in SKILL.md. No gesture, no shared value — a CSS transition is the whole implementation.
 
 ```jsx
-import Animated from 'react-native-reanimated';
+import Animated, { cubicBezier } from 'react-native-reanimated';
 import { Pressable, StyleSheet } from 'react-native';
 
 function PressableScale({ onPress, children }) {
@@ -112,7 +112,7 @@ const styles = StyleSheet.create({
     transform: [{ scale: 1 }],
     transitionProperty: 'transform',
     transitionDuration: '120ms',
-    transitionTimingFunction: 'cubic-bezier(0.23, 1, 0.32, 1)',
+    transitionTimingFunction: cubicBezier(0.23, 1, 0.32, 1),
   },
   pressed: { transform: [{ scale: 0.97 }] },
 });

--- a/plugins/expo/skills/expo-animation/SKILL.md
+++ b/plugins/expo/skills/expo-animation/SKILL.md
@@ -126,12 +126,18 @@ Reanimated's spring takes Apple's two designer parameters directly — use this 
 **Never `ease-in` on UI.** It starts slow, delaying the exact moment the user is watching. Reanimated's built-ins are as weak as CSS's — use these:
 
 ```js
-import { Easing } from 'react-native-reanimated';
+import { cubicBezier, Easing } from 'react-native-reanimated';
 
+// transitionTimingFunction / animationTimingFunction
+const CSS_EASE_OUT = cubicBezier(0.23, 1, 0.32, 1);
+
+// withTiming / .easing(...)
 const EASE_OUT = Easing.bezier(0.23, 1, 0.32, 1);      // strong ease-out for UI
 const EASE_IN_OUT = Easing.bezier(0.77, 0, 0.175, 1);  // on-screen movement
 const EASE_SHEET = Easing.bezier(0.32, 0.72, 0, 1);    // iOS sheet curve
 ```
+
+Reanimated 4.1.1 and 4.5.1 reject raw `'cubic-bezier(...)'` strings. CSS transitions and animations use `cubicBezier(...)`; `withTiming` and `.easing(...)` use `Easing.bezier(...)`.
 
 **Duration:**
 
@@ -238,6 +244,7 @@ For ready-to-build implementations — press feedback, drag-to-dismiss sheet, sw
 | A screen transition rebuilt in JS | native stack `animation` |
 | Sliding between tabs | `animation: 'none'` |
 | `Easing.in(...)` on a UI element | `Easing.bezier(0.23, 1, 0.32, 1)` |
+| `'cubic-bezier(...)'` in a Reanimated CSS style | `cubicBezier(...)` from `react-native-reanimated` |
 | `scale(0)` entrance | `scale(0.95)` + `opacity: 0` |
 | Distance-only dismissal threshold | velocity **or** distance — a flick is enough |
 | Hard stop at a boundary | rubber-band resistance |


### PR DESCRIPTION
## Summary

- replace the invalid web-style `cubic-bezier(...)` string in the `expo-animation` press-feedback recipe with Reanimated's `cubicBezier(...)` helper
- distinguish CSS `cubicBezier(...)` from the `Easing.bezier(...)` API used by `withTiming` and `.easing(...)`
- document the behavior reported against Reanimated 4.1.1 and 4.5.1
- bump the Expo plugin manifests from 1.12.4 to 1.12.5

## Upstream sync

`expo-animation` is based on Emil Kowalski's `animate-expo` skill. The same fix was sent to Emil for upstream consideration in [davidmokos/emilkowalski-skills#1](https://github.com/davidmokos/emilkowalski-skills/pull/1).

## Agent feedback

Expo received the following reports from agents using the skill. This PR tracks [ENG-26095](https://linear.app/expo/issue/ENG-26095/recipesmd-and-skillmd-use-invalid-cubic-bezier-string-for-reanimated).

<details>
<summary>Cursor — Reanimated 4.5.1</summary>

> Reanimated 4.5.1 (Expo SDK 57) CSS transitions reject the string `cubic-bezier(...)` used in RECIPES.md PressableScale. Error: Invalid predefined timing function. Supported string values are only linear/ease/ease-in/ease-out/ease-in-out/step-start/step-end. Custom curves need the `cubicBezier()` helper from `react-native-reanimated`, e.g. `transitionTimingFunction: cubicBezier(0.23, 1, 0.32, 1)`.

</details>

<details>
<summary>Claude Code — Reanimated 4.1.1 / Expo SDK 54</summary>

> RECIPES.md's press-feedback recipe and the SKILL.md easing constants both use `transitionTimingFunction: 'cubic-bezier(0.23, 1, 0.32, 1)'` as a CSS-transition style value. On this project's installed `react-native-reanimated` (4.1.1) this throws at render: `[Reanimated] Invalid predefined timing function "cubic-bezier(0.23, 1, 0.32, 1)". Supported values are: linear, ease, ease-in, ease-out, ease-in-out, step-start, step-end.` The CSS-transition `transitionTimingFunction` prop appears to only accept that fixed keyword list in this version, not an arbitrary `cubic-bezier()` string the way real CSS or Reanimated's non-CSS `Easing.bezier()` does. Worked around by using `ease-out` instead. Might be worth a version-compatibility note in the skill, or confirming whether a newer/older Reanimated version actually supports the cubic-bezier string form.

</details>

<details>
<summary>Claude Code — API distinction</summary>

> The animate-expo skill recommends Reanimated CSS transitions (`transitionProperty` in the style) and separately provides `Easing.bezier(...)` curve constants. Passing a `cubic-bezier(...)` string to `transitionTimingFunction` throws at render: `Invalid predefined timing function`. CSS transitions require the `cubicBezier()` helper exported from `react-native-reanimated`, while `Easing.bezier` belongs to `withTiming`. Worth stating explicitly which easing form belongs to which API.

</details>

<details>
<summary>Claude Code — Reanimated 4.5.1 / Expo SDK 57</summary>

> RECIPES.md Press feedback recipe uses `transitionTimingFunction: 'cubic-bezier(0.23, 1, 0.32, 1)'` in a plain style object. On `react-native-reanimated` 4.5.1 this throws at runtime: `[Reanimated] Invalid predefined timing function "cubic-bezier(0.23, 1, 0.32, 1)". Supported values are: linear, ease, ease-in, ease-out, ease-in-out, step-start, step-end.` CSS `transitionTimingFunction` only accepts the named keywords in this Reanimated version—arbitrary `cubic-bezier()` strings are not supported there. They work for the imperative `Easing.bezier()` / `withTiming()` API, just not as a CSS `transitionTimingFunction` string. This was encountered while building a `backgroundColor` CSS transition on a login screen. Recommend either noting the keyword-only constraint next to the recipe or swapping the sample to a supported keyword so copy-pasted code does not crash on first run.

</details>

## Validation

- `claude plugin validate .`
- `claude plugin validate ./plugins/expo`
- `bun scripts/check-skill-limits.ts`
- `bun scripts/check-plugin-version-bump.ts origin/main`
- parsed all four changed plugin manifests with `python3 -m json.tool`
- confirmed no raw `cubic-bezier(...)` value remains in an `expo-animation` `transitionTimingFunction` or `animationTimingFunction`
