### PR TITLE
[skills] Add EAS Update skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Skills whose core purpose uses paid Expo Application Services (EAS).
 | `eas-hosting` | Deploying Expo websites and Expo Router API routes to EAS Hosting: secrets, custom domains, Cloudflare Workers. |
 | `eas-workflows` | EAS Workflow YAML files and CI/CD automation. |
 | `eas-observe` | EAS Observe setup and launch, route, event, and version metrics. |
+| `eas-update` | EAS Update setup, OTA publishing, runtime compatibility, testing, and debugging. |
 | `eas-update-insights` | EAS Update health, crash rates, launch counts, payload size, and rollout gates. |
 | `eas-simulator` | Run and drive your app on a remote iOS simulator or Android emulator on EAS cloud - from the CLI or an agent, with a live browser preview (iOS only). |
 

--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Expo",
   "displayName": "Expo",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "description": "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.grok-plugin/plugin.json
+++ b/plugins/expo/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "description": "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/README.md
+++ b/plugins/expo/README.md
@@ -30,6 +30,7 @@ Skills come in two groups so the free vs paid boundary stays clear: open-source 
 - Covers EAS Build configuration and version management
 - Helps write and validate EAS Workflow YAML files for CI/CD
 - Checks EAS Update health, adoption, crash rates, and payload size
+- Configures, publishes, tests, and debugs over-the-air updates with EAS Update
 - Tracks production performance with EAS Observe
 - Covers website and API route authoring and deployment with EAS Hosting
 - Runs and drives your app on remote iOS/Android simulators on EAS cloud
@@ -61,6 +62,7 @@ Skills come in two groups so the free vs paid boundary stays clear: open-source 
 - Configuring EAS Build profiles
 - Writing CI/CD workflows for automated deployments
 - Inspecting EAS Update rollout health and adoption
+- Configuring, publishing, testing, or debugging an EAS Update
 - Tracking startup, navigation, and event performance with EAS Observe
 - Deploying a website or Expo Router API routes to EAS Hosting
 - Running your app on a remote cloud simulator when no local simulator is available
@@ -96,6 +98,7 @@ Skills come in two groups so the free vs paid boundary stays clear: open-source 
 - **eas-hosting** - Deploy Expo websites and API routes to EAS Hosting (secrets, custom domains, Cloudflare Workers)
 - **eas-workflows** - EAS workflow YAML files for CI/CD pipelines
 - **eas-observe** - EAS Observe setup and launch, route, event, and version metrics
+- **eas-update** - Configure, publish, test, and debug over-the-air updates
 - **eas-update-insights** - Check EAS Update health, crash rates, adoption, and payload size
 - **eas-simulator** - Run and drive your app on a remote iOS/Android simulator on EAS cloud, from the CLI or an AI agent
 

--- a/plugins/expo/skills/README.md
+++ b/plugins/expo/skills/README.md
@@ -43,6 +43,7 @@ Skills whose core purpose uses paid Expo Application Services (EAS). Description
 | `eas-hosting` | Deploying Expo websites and Expo Router API routes to EAS Hosting: secrets, custom domains, Cloudflare Workers. | EAS Hosting usage |
 | `eas-workflows` | EAS Workflow YAML files and CI/CD automation. | EAS build/compute minutes |
 | `eas-observe` | EAS Observe setup and launch, route, event, and version metrics. | EAS Observe usage |
+| `eas-update` | EAS Update setup, OTA publishing, runtime compatibility, testing, and debugging. | EAS Update usage |
 | `eas-update-insights` | EAS Update health, crash rates, launch counts, payload size, and rollout gates. | EAS Update usage |
 | `eas-simulator` | Remote iOS/Android simulators on EAS cloud, driven from the CLI or an agent, with browser preview. | EAS Simulator usage |
 

--- a/plugins/expo/skills/eas-update/SKILL.md
+++ b/plugins/expo/skills/eas-update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: eas-update
-description: "EAS service (paid). Configure and use EAS Update for over-the-air JavaScript and asset updates with expo-updates and EAS CLI. Use when setting up OTA updates, running eas update:configure or eas update, publishing to preview/staging/production channels, explaining branches/channels/runtime versions, testing an update in a development or release/TestFlight build, or debugging why a build did not receive an update. Not for update health metrics; use eas-update-insights for adoption, crashes, and rollout monitoring."
+description: "EAS service (paid). Configure and use EAS Update for over-the-air JavaScript and asset updates with expo-updates and EAS CLI. Use when setting up OTA updates, running eas update:configure or eas update, publishing to preview/staging/production channels, explaining branches/channels/runtime versions, testing updates, or debugging why an installed build still shows old code. Load for TestFlight, preview, or production updates that do not appear, including questions about cold launches or reopening the app. Not for update health metrics; use eas-update-insights for adoption, crashes, and rollout monitoring."
 version: 1.0.0
 license: MIT
 allowed-tools: "Bash(npx expo *), Bash(npx *eas-cli@*), Bash(eas *)"
@@ -58,6 +58,8 @@ Use this model to make decisions, but explain only the concepts needed for the u
 Use an update for changes to JavaScript, styling, and bundled assets that the installed native runtime already supports.
 
 Create a new native build when a change adds or modifies native code or native configuration, including most native-library additions and SDK upgrades. Do not work around a runtime mismatch or imply that publishing can add native capabilities to an existing build. See https://docs.expo.dev/eas-update/runtime-versions/.
+
+Do not change the project's runtime-version policy as an incidental fix. Explain how the current policy affects compatibility; treat changing it as a separate decision because it changes which installed builds can receive future updates.
 
 ## Publish deliberately
 

--- a/plugins/expo/skills/eas-update/SKILL.md
+++ b/plugins/expo/skills/eas-update/SKILL.md
@@ -30,6 +30,8 @@ npx eas-cli@latest update:configure
 
 Use `eas update:configure` rather than manually inventing `updates.url`, `runtimeVersion`, native metadata, or build-profile channels. The command understands EAS project linking, Continuous Native Generation, and projects with committed native directories. Review and explain its resulting diff.
 
+If the command cannot proceed because the project is not linked or the user has not authorized the required remote operation, stop after any independently valid package installation and explain what remains. Do not partially reproduce `update:configure` by adding a runtime-version policy, config plugin, update URL, or channels by hand.
+
 For dynamic app config, non-EAS builds, or a command that cannot complete automatically, follow the current setup documentation instead of guessing: https://docs.expo.dev/eas-update/getting-started/.
 
 ## Keep the model straight

--- a/plugins/expo/skills/eas-update/SKILL.md
+++ b/plugins/expo/skills/eas-update/SKILL.md
@@ -14,7 +14,14 @@ Use EAS Update to deliver compatible JavaScript, styling, and asset changes to i
 
 ## Start with the supported configuration path
 
-Before changing anything, inspect `package.json`, the Expo app config, `eas.json` if present, and whether `ios/` or `android/` are committed. Detect the Expo SDK version and preserve existing dynamic or platform-specific configuration.
+Before changing anything, inspect `package.json`, the Expo app config, `eas.json` if present, and whether `ios/` or `android/` are tracked. Use what you find when reviewing the CLI's changes:
+
+- Preserve existing dynamic or platform-specific app configuration.
+- If `eas.json` exists, preserve its profiles and existing channel assignments. The CLI adds a channel matching the profile name only to build profiles that do not already have one.
+- If `eas.json` is absent, do not create it by hand. The CLI may direct the user to run `eas build:configure` separately.
+- With tracked native projects, expect the CLI to synchronize the platform's native Update configuration. Without them, expect Continuous Native Generation to apply the native configuration during a later build.
+
+Detect the Expo SDK version before installing packages or interpreting version-specific behavior.
 
 If `expo-updates` is not installed, install the SDK-compatible version:
 
@@ -32,7 +39,7 @@ Use `eas update:configure` rather than manually inventing `updates.url`, `runtim
 
 If the command cannot proceed because the project is not linked or the user has not authorized the required remote operation, stop after any independently valid package installation and explain what remains. Do not partially reproduce `update:configure` by adding a runtime-version policy, config plugin, update URL, or channels by hand.
 
-For dynamic app config, non-EAS builds, or a command that cannot complete automatically, follow the current setup documentation instead of guessing: https://docs.expo.dev/eas-update/getting-started/.
+For dynamic app config, non-EAS builds, or a command that cannot complete automatically, follow the current setup documentation instead of guessing: https://docs.expo.dev/eas-update/getting-started.md.
 
 ## Keep the model straight
 
@@ -59,7 +66,7 @@ Use this model to make decisions, but explain only the concepts needed for the u
 
 Use an update for changes to JavaScript, styling, and bundled assets that the installed native runtime already supports.
 
-Create a new native build when a change adds or modifies native code or native configuration, including most native-library additions and SDK upgrades. Do not work around a runtime mismatch or imply that publishing can add native capabilities to an existing build. See https://docs.expo.dev/eas-update/runtime-versions/.
+Create a new native build when a change adds or modifies native code or native configuration, including most native-library additions and SDK upgrades. Do not work around a runtime mismatch or imply that publishing can add native capabilities to an existing build. See https://docs.expo.dev/eas-update/runtime-versions.md.
 
 Do not change the project's runtime-version policy as an incidental fix. Explain how the current policy affects compatibility; treat changing it as a separate decision because it changes which installed builds can receive future updates.
 
@@ -84,7 +91,7 @@ SDK 55 and later require an EAS environment for publishing. Choose the environme
 
 Publishing changes remote state and can affect installed applications. Before running it, establish the exact project, channel, environment, platforms, runtime version, and message. Publish to production only when the user has explicitly requested or approved it; if the authorization or target is ambiguous, stop before the command and ask. Do not infer a production destination solely from the current Git branch.
 
-Prefer a preview or staging channel for validation. When promoting a tested update, use the documented deployment flow so production receives the same artifact where possible: https://docs.expo.dev/eas-update/deployment/.
+Prefer a preview or staging channel for validation. When promoting a tested update, use the documented deployment flow so production receives the same artifact where possible: https://docs.expo.dev/eas-update/deployment.md.
 
 ## Test according to the build type
 
@@ -112,23 +119,23 @@ Check these in order:
 3. Confirm the build actually contains the expected update URL and channel; app-config changes take effect only in a newly compiled build.
 4. Inspect the channel-to-branch mapping and the active update on that branch.
 5. Fully terminate the release build and allow for the normal download-then-apply lifecycle.
-6. Use the current debugging guide for native logs, export problems, and configuration checks: https://docs.expo.dev/eas-update/debug/.
+6. Use the current debugging guide for native logs, export problems, and configuration checks: https://docs.expo.dev/eas-update/debug.md.
 
 Never bypass a compatibility or anti-bricking safeguard merely to make an update appear.
 
 ## Advanced and adjacent workflows
 
-- **Channel surfing:** an individual release build can override its `expo-channel-name` request header to request another compatible channel. This differs from changing the server-side channel-to-branch mapping. Follow https://docs.expo.dev/eas-update/channel-surfing/ and preserve its access-control, persistence, recovery, and compatibility constraints.
+- **Channel surfing:** an individual release build can override its `expo-channel-name` request header to request another compatible channel. This differs from changing the server-side channel-to-branch mapping. Follow https://docs.expo.dev/eas-update/channel-surfing.md and preserve its access-control, persistence, recovery, and compatibility constraints.
 - **Update health:** load `eas-update-insights` for adoption, launch failures, crash rate, payload size, and rollout monitoring after publishing.
 - **Store releases:** load `eas-app-stores` when native changes require a new TestFlight, App Store, or Play Store build.
 
 ## Official references
 
-- Setup: https://docs.expo.dev/eas-update/getting-started/
-- Concepts and matching: https://docs.expo.dev/eas-update/how-it-works/
-- Deployment: https://docs.expo.dev/eas-update/deployment/
-- Debugging: https://docs.expo.dev/eas-update/debug/
-- Current EAS CLI reference: https://docs.expo.dev/eas/cli/
+- Setup: https://docs.expo.dev/eas-update/getting-started.md
+- Concepts and matching: https://docs.expo.dev/eas-update/how-it-works.md
+- Deployment: https://docs.expo.dev/eas-update/deployment.md
+- Debugging: https://docs.expo.dev/eas-update/debug.md
+- Current EAS CLI reference: https://docs.expo.dev/eas/cli.md
 
 ## Submitting Feedback
 If you encounter errors, misleading or outdated information in this skill, report it so Expo can improve:

--- a/plugins/expo/skills/eas-update/SKILL.md
+++ b/plugins/expo/skills/eas-update/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: eas-update
+description: "EAS service (paid). Configure and use EAS Update for over-the-air JavaScript and asset updates with expo-updates and EAS CLI. Use when setting up OTA updates, running eas update:configure or eas update, publishing to preview/staging/production channels, explaining branches/channels/runtime versions, testing an update in a development or release/TestFlight build, or debugging why a build did not receive an update. Not for update health metrics; use eas-update-insights for adoption, crashes, and rollout monitoring."
+version: 1.0.0
+license: MIT
+allowed-tools: "Bash(npx expo *), Bash(npx *eas-cli@*), Bash(eas *)"
+---
+
+# EAS Update
+
+> **EAS service - costs apply.** EAS Update is available on the Free plan; publishing and delivery use update, bandwidth, and storage allowances, with higher limits on paid plans. See https://expo.dev/pricing.
+
+Use EAS Update to deliver compatible JavaScript, styling, and asset changes to installed apps without submitting a new native binary. Native-code changes still require a new build.
+
+## Start with the supported configuration path
+
+Before changing anything, inspect `package.json`, the Expo app config, `eas.json` if present, and whether `ios/` or `android/` are committed. Detect the Expo SDK version and preserve existing dynamic or platform-specific configuration.
+
+If `expo-updates` is not installed, install the SDK-compatible version:
+
+```bash
+npx expo install expo-updates
+```
+
+Configure from the project root:
+
+```bash
+npx eas-cli@latest update:configure
+```
+
+Use `eas update:configure` rather than manually inventing `updates.url`, `runtimeVersion`, native metadata, or build-profile channels. The command understands EAS project linking, Continuous Native Generation, and projects with committed native directories. Review and explain its resulting diff.
+
+For dynamic app config, non-EAS builds, or a command that cannot complete automatically, follow the current setup documentation instead of guessing: https://docs.expo.dev/eas-update/getting-started/.
+
+## Keep the model straight
+
+- **Build:** the installed native app. It contains native code, an embedded update, a platform, a runtime version, and normally a channel fixed at build time.
+- **Update:** a published JavaScript bundle, assets, and metadata for one platform and runtime version.
+- **Branch:** an ordered stream of updates. Its newest compatible update is active.
+- **Channel:** a stable deployment target embedded in builds. On the server, it points to a branch.
+- **Runtime version:** the compatibility boundary between an update and the native code in a build.
+
+A build receives an update only when platform and runtime version match and the build's channel points to the branch containing that update:
+
+```text
+installed build (channel: production, runtime: 1.1.1, platform: ios)
+  -> production channel
+  -> production branch
+  -> newest update for runtime 1.1.1 and ios
+```
+
+Channels and branches commonly have the same name, but they are separate objects. `eas channel:edit` changes a channel's server-side branch mapping for every build on that channel. It does not change an individual installation's embedded channel.
+
+Use this model to make decisions, but explain only the concepts needed for the user's request rather than reciting the entire model every time.
+
+## Decide whether an update is compatible
+
+Use an update for changes to JavaScript, styling, and bundled assets that the installed native runtime already supports.
+
+Create a new native build when a change adds or modifies native code or native configuration, including most native-library additions and SDK upgrades. Do not work around a runtime mismatch or imply that publishing can add native capabilities to an existing build. See https://docs.expo.dev/eas-update/runtime-versions/.
+
+## Publish deliberately
+
+Check the current CLI help before relying on remembered flags:
+
+```bash
+npx eas-cli@latest update --help
+```
+
+For the common channel-based flow:
+
+```bash
+npx eas-cli@latest update \
+  --channel <channel> \
+  --message "<message>" \
+  --environment <environment>
+```
+
+SDK 55 and later require an EAS environment for publishing. Choose the environment intentionally so exported code receives the intended variables.
+
+Publishing changes remote state and can affect installed applications. Before running it, establish the exact project, channel, environment, platforms, runtime version, and message. Publish to production only when the user has explicitly requested or approved it; if the authorization or target is ambiguous, stop before the command and ask. Do not infer a production destination solely from the current Git branch.
+
+Prefer a preview or staging channel for validation. When promoting a tested update, use the documented deployment flow so production receives the same artifact where possible: https://docs.expo.dev/eas-update/deployment/.
+
+## Test according to the build type
+
+### Development builds
+
+Preview updates with the development build's Extensions UI, the EAS dashboard, or Expo Orbit. A normal `expo-dev-client` development build does not behave like a release build's automatic startup update flow.
+
+### Preview, TestFlight, and production builds
+
+Release builds normally prioritize startup speed. With the default launch behavior, the app may start its current embedded or cached update while downloading a newly published update in the background. The downloaded update is applied on a later restart.
+
+For manual QA, fully terminate the app rather than backgrounding it, reopen it, allow the update time to download, and, if the change is not visible, fully terminate and reopen it once more. Describe this as **up to two cold launches**, not a TestFlight-specific ritual:
+
+1. One launch can discover and download the update.
+2. The following launch can run the downloaded update.
+
+Do not automatically change `fallbackToCacheTimeout` to avoid the second launch. Waiting at startup trades launch latency and reliability for faster update activation. If the app needs an intentional update UX, consider the `expo-updates` APIs for checking, fetching, and presenting a non-blocking restart action. Use the `expo-updates` API reference for the project's detected SDK version.
+
+## Debug a build that did not update
+
+Check these in order:
+
+1. Confirm the update was published to the intended EAS project, channel or branch, platform, and environment.
+2. Compare the installed build's platform and runtime version with the published update.
+3. Confirm the build actually contains the expected update URL and channel; app-config changes take effect only in a newly compiled build.
+4. Inspect the channel-to-branch mapping and the active update on that branch.
+5. Fully terminate the release build and allow for the normal download-then-apply lifecycle.
+6. Use the current debugging guide for native logs, export problems, and configuration checks: https://docs.expo.dev/eas-update/debug/.
+
+Never bypass a compatibility or anti-bricking safeguard merely to make an update appear.
+
+## Advanced and adjacent workflows
+
+- **Channel surfing:** an individual release build can override its `expo-channel-name` request header to request another compatible channel. This differs from changing the server-side channel-to-branch mapping. Follow https://docs.expo.dev/eas-update/channel-surfing/ and preserve its access-control, persistence, recovery, and compatibility constraints.
+- **Update health:** load `eas-update-insights` for adoption, launch failures, crash rate, payload size, and rollout monitoring after publishing.
+- **Store releases:** load `eas-app-stores` when native changes require a new TestFlight, App Store, or Play Store build.
+
+## Official references
+
+- Setup: https://docs.expo.dev/eas-update/getting-started/
+- Concepts and matching: https://docs.expo.dev/eas-update/how-it-works/
+- Deployment: https://docs.expo.dev/eas-update/deployment/
+- Debugging: https://docs.expo.dev/eas-update/debug/
+- Current EAS CLI reference: https://docs.expo.dev/eas/cli/
+
+## Submitting Feedback
+If you encounter errors, misleading or outdated information in this skill, report it so Expo can improve:
+```bash
+npx --yes submit-expo-feedback@latest --category skills --subject "eas-update" "<actionable feedback>"
+```
+Only submit when you have something specific and actionable to report. Include as much relevant context as possible.
+If an AI agent repeatedly failed or the user had to take over an Expo task, load the expo-skill-feedback skill and follow its eval-candidate flow instead of reusing the command above.

--- a/plugins/expo/skills/eas-update/agents/openai.yaml
+++ b/plugins/expo/skills/eas-update/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "EAS Update"
+  short_description: "Paid EAS service. Configure, publish, test, and debug over-the-air updates with expo-updates and EAS CLI"
+  default_prompt: "Use $eas-update to configure EAS Update, publish a compatible OTA update to the intended channel, test it in development or release builds, and debug channel or runtime-version mismatches."

--- a/plugins/expo/skills/expo-overview/SKILL.md
+++ b/plugins/expo/skills/expo-overview/SKILL.md
@@ -45,6 +45,7 @@ Match the goal to a category, then the skill, then load that leaf's `SKILL.md`.
 - `eas-workflows` — EAS Workflow YAML and CI/CD pipelines
 - `eas-simulator` — run and drive the app on a remote iOS / Android simulator on EAS cloud
 - `expo-dev-client` — custom development builds
+- `eas-update` — configure, publish, test, and debug compatible over-the-air updates
 - `eas-update-insights` — OTA update health: crash rate, adoption, payload size
 - `eas-observe` — startup / launch / TTI performance with EAS Observe
 

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -33,6 +33,7 @@
         "eas-hosting",
         "eas-workflows",
         "eas-observe",
+        "eas-update",
         "eas-update-insights",
         "eas-simulator"
       ]


### PR DESCRIPTION
## Why

Addresses [ENG-25468](https://linear.app/expo/issue/ENG-25468/add-agent-skill-for-eas-update).

Agents do not always choose the right path when configuring EAS Update.  They've shown behaviors like editing app configuration manually instead of running `eas update:configure`, and their knowledge / guidance on runtime compatibility and release-build activation can be incomplete or misleading.

Other examples and supporting context:
- A TestFlight user does not see an update after opening once
- An agent may say "reopen twice" without explaining why
- An agent may try to publish a native change as an OTA update
- Vague prompts like "push to prod" may lead an agent to attempt dangerous operations without first resolving the target

This adds a focused skill for configuring, publishing, testing, and debugging EAS Update without duplicating the full product documentation.

## How

I added an `eas-update` skill that starts by inspecting the project and uses the existing EAS CLI for configuration. It gives agents enough of the builds, channels, branches, updates, and runtime-version model to make compatibility decisions and explain why an installed build did or did not receive an update.

The skill covers bounded production publishing, download and apply lifecycle in release builds, and debugging instructions for project, channel, platform, runtime, and embedded configuration mismatches. It routes update health questions to `eas-update-insights` and native release work to `eas-app-stores`.

## Test Plan

Repository validation suite:

- `claude plugin validate .`
- `claude plugin validate ./plugins/expo`
- `bun scripts/check-skill-limits.ts`
- `bun scripts/check-overview-routing.ts`
- `bun scripts/check-plugin-version-bump.ts origin/main`
- `bun test scripts/check-plugin-version-bump.test.ts` (20 passed)
- JSON parsing and `git diff --check`

Fresh Claude sessions results against the local plugin:

| Scenario | Expected behavior | Observed |
| --- | --- | --- |
| Configure OTA updates | Inspect the project and use `expo install expo-updates` plus `eas update:configure` instead of inventing configuration | Loaded `eas-update`, installed the SDK-compatible package, and stopped before remote linking without partially reproducing `update:configure` by hand |
| TestFlight still shows old code | Explain background download and application on a later cold launch, then check channel, platform, and runtime compatibility | Three different phrasings loaded `eas-update` on `sonnet[1m]` and explained the up-to-two-cold-launch behavior |
| Publish a native dependency OTA | Reject the incompatible OTA path and require a new native build without changing runtime policy as a side effect | Loaded `eas-update`, refused to publish, required a new build, and preserved the existing runtime-version policy |
| Push a fix to production | Resolve the project, release type, channel, environment, platform, runtime, and authorization before publishing | Loaded the Expo router and stopped because the repository and production target were ambiguous |
| Check update health | Route crash, adoption, and rollout questions away from the general publishing workflow | Did not select `eas-update` and identified `eas-update-insights` as the appropriate workflow |
| Release changed iOS entitlements | Recognize native configuration and use the store-release workflow | Loaded `eas-app-stores` and required a new native build |
| Switch one QA installation to preview | Use per-installation channel surfing without globally remapping production | Loaded `eas-update`, rejected `eas channel:edit`, and used the device-local request-header override |


