### PR TITLE
Extend skill evaluations with focused cases and trace evidence

### DIFF
--- a/.eas/workflows/skill-eval-ci.yml
+++ b/.eas/workflows/skill-eval-ci.yml
@@ -1,12 +1,5 @@
-# Skill eval for PRs labeled "eval". Advisory, never blocks merge.
-# Authors+evaluates 3 PRDs vs main and this PR. "_main" jobs cache via
-# fingerprint+restore_cache; only skill-eval-main-baseline.yml writes that
-# cache. Logic in scripts/*: EAS caps workflow files at 16 KiB.
-# Authoring model: AGENT_MODEL in scripts/ci.sh, shared by both workflows.
 name: skill-eval-ci
 
-# Must match eval-harness's own .eas/workflows/*.yml. The default worker image
-# ships Bun 1.0.14 / Node 18, too old for the analyzer to write metrics.json.
 defaults:
   image: sdk-57
   tools:
@@ -337,7 +330,6 @@ jobs:
           name: skill-eval-report-wiki_reader-pr
           path: skill-eval-report-wiki_reader-pr.tar.gz
 
-  # after: (not needs:) posts even if some jobs failed.
   comment:
     name: comment
     after:
@@ -353,9 +345,7 @@ jobs:
     params:
       payload: |
         <!-- expo-skill-eval -->
-        ## Expo skill eval
 
-        ### Triggers
 
         | App | Expected | main (recall/precision) | PR (recall/precision) |
         |---|---|---|---|
@@ -363,7 +353,6 @@ jobs:
         | hot_chocolate | ${{ after.se_hot_chocolate_pr.outputs.expected }} | ${{ after.se_hot_chocolate_main.outputs.detected }} (${{ after.se_hot_chocolate_main.outputs.recall }} / ${{ after.se_hot_chocolate_main.outputs.precision }}) | ${{ after.se_hot_chocolate_pr.outputs.detected }} (${{ after.se_hot_chocolate_pr.outputs.recall }} / ${{ after.se_hot_chocolate_pr.outputs.precision }}) |
         | wiki_reader | ${{ after.se_wiki_reader_pr.outputs.expected }} | ${{ after.se_wiki_reader_main.outputs.detected }} (${{ after.se_wiki_reader_main.outputs.recall }} / ${{ after.se_wiki_reader_main.outputs.precision }}) | ${{ after.se_wiki_reader_pr.outputs.detected }} (${{ after.se_wiki_reader_pr.outputs.recall }} / ${{ after.se_wiki_reader_pr.outputs.precision }}) |
 
-        ### Code quality
 
         Lexical/structural: passed/total. Failing: PR only.
 
@@ -376,7 +365,6 @@ jobs:
         | wiki_reader | main | ${{ after.se_wiki_reader_main.outputs.lexical }} | ${{ after.se_wiki_reader_main.outputs.structural }} | ${{ after.se_wiki_reader_main.outputs.syntax_ok }} | ${{ after.se_wiki_reader_main.outputs.bundle_ok }} | — |
         | wiki_reader | PR | ${{ after.se_wiki_reader_pr.outputs.lexical }} | ${{ after.se_wiki_reader_pr.outputs.structural }} | ${{ after.se_wiki_reader_pr.outputs.syntax_ok }} | ${{ after.se_wiki_reader_pr.outputs.bundle_ok }} | ${{ after.se_wiki_reader_pr.outputs.failing }} |
 
-        ### Focused catalog-value pilot
 
         Four cases × three trials, with and without Expo skills. Pending reviews are not passes; source checks do not establish native-runtime correctness.
 

--- a/.eas/workflows/skill-eval-ci.yml
+++ b/.eas/workflows/skill-eval-ci.yml
@@ -345,7 +345,9 @@ jobs:
     params:
       payload: |
         <!-- expo-skill-eval -->
+        ## Expo skill eval
 
+        ### Triggers
 
         | App | Expected | main (recall/precision) | PR (recall/precision) |
         |---|---|---|---|
@@ -353,6 +355,7 @@ jobs:
         | hot_chocolate | ${{ after.se_hot_chocolate_pr.outputs.expected }} | ${{ after.se_hot_chocolate_main.outputs.detected }} (${{ after.se_hot_chocolate_main.outputs.recall }} / ${{ after.se_hot_chocolate_main.outputs.precision }}) | ${{ after.se_hot_chocolate_pr.outputs.detected }} (${{ after.se_hot_chocolate_pr.outputs.recall }} / ${{ after.se_hot_chocolate_pr.outputs.precision }}) |
         | wiki_reader | ${{ after.se_wiki_reader_pr.outputs.expected }} | ${{ after.se_wiki_reader_main.outputs.detected }} (${{ after.se_wiki_reader_main.outputs.recall }} / ${{ after.se_wiki_reader_main.outputs.precision }}) | ${{ after.se_wiki_reader_pr.outputs.detected }} (${{ after.se_wiki_reader_pr.outputs.recall }} / ${{ after.se_wiki_reader_pr.outputs.precision }}) |
 
+        ### Code quality
 
         Lexical/structural: passed/total. Failing: PR only.
 
@@ -365,6 +368,7 @@ jobs:
         | wiki_reader | main | ${{ after.se_wiki_reader_main.outputs.lexical }} | ${{ after.se_wiki_reader_main.outputs.structural }} | ${{ after.se_wiki_reader_main.outputs.syntax_ok }} | ${{ after.se_wiki_reader_main.outputs.bundle_ok }} | — |
         | wiki_reader | PR | ${{ after.se_wiki_reader_pr.outputs.lexical }} | ${{ after.se_wiki_reader_pr.outputs.structural }} | ${{ after.se_wiki_reader_pr.outputs.syntax_ok }} | ${{ after.se_wiki_reader_pr.outputs.bundle_ok }} | ${{ after.se_wiki_reader_pr.outputs.failing }} |
 
+        ### Focused catalog-value pilot
 
         Four cases × three trials, with and without Expo skills. Pending reviews are not passes; source checks do not establish native-runtime correctness.
 

--- a/.eas/workflows/skill-eval-ci.yml
+++ b/.eas/workflows/skill-eval-ci.yml
@@ -89,6 +89,7 @@ jobs:
       SCENARIO: skills_available_unmentioned
     outputs:
       report: ${{ steps.run.outputs.report }}
+      focused: ${{ steps.run.outputs.focused }}
       expected: ${{ steps.run.outputs.expected }}
       detected: ${{ steps.run.outputs.detected }}
       recall: ${{ steps.run.outputs.recall }}
@@ -107,6 +108,7 @@ jobs:
           bash scripts/ci.sh author_and_evaluate false - "$(pwd)/plugins/expo" skill-eval-report-notes-pr "${SCENARIO}" skill-eval-report-notes-pr.tar.gz
           eval "$(python3 scripts/ci.py print-outputs skill-eval-report-notes-pr/metrics.json)"
           set-output report "$report"
+          set-output focused "$focused"
           set-output expected "$expected"
           set-output detected "$detected"
           set-output recall "$recall"
@@ -373,5 +375,13 @@ jobs:
         | hot_chocolate | PR | ${{ after.se_hot_chocolate_pr.outputs.lexical }} | ${{ after.se_hot_chocolate_pr.outputs.structural }} | ${{ after.se_hot_chocolate_pr.outputs.syntax_ok }} | ${{ after.se_hot_chocolate_pr.outputs.bundle_ok }} | ${{ after.se_hot_chocolate_pr.outputs.failing }} |
         | wiki_reader | main | ${{ after.se_wiki_reader_main.outputs.lexical }} | ${{ after.se_wiki_reader_main.outputs.structural }} | ${{ after.se_wiki_reader_main.outputs.syntax_ok }} | ${{ after.se_wiki_reader_main.outputs.bundle_ok }} | — |
         | wiki_reader | PR | ${{ after.se_wiki_reader_pr.outputs.lexical }} | ${{ after.se_wiki_reader_pr.outputs.structural }} | ${{ after.se_wiki_reader_pr.outputs.syntax_ok }} | ${{ after.se_wiki_reader_pr.outputs.bundle_ok }} | ${{ after.se_wiki_reader_pr.outputs.failing }} |
+
+        ### Focused catalog-value pilot
+
+        Four cases × three trials, with and without Expo skills. Pending reviews are not passes; source checks do not establish native-runtime correctness.
+
+        ${{ after.se_notes_pr.outputs.focused }}
+
+        Open `focused/report.html` inside the Notes PR artifact for outcomes, routing, costs and traces.
 
         📎 [Reports](${{ workflow.url }})

--- a/.eas/workflows/skill-eval-focused.yml
+++ b/.eas/workflows/skill-eval-focused.yml
@@ -10,10 +10,15 @@ defaults:
 on:
   workflow_dispatch:
     inputs:
+      experiment:
+        type: choice
+        options: [catalog-value, catalog-change]
+        default: catalog-value
+        description: With/without Expo skills, or main versus candidate
       case_id:
         type: string
-        default: native-form-advice
-        description: Case ID, or all to run the selected split
+        default: pilot
+        description: Case ID, pilot (four cases), or all in the selected split
       split:
         type: choice
         options: [development, validation, holdout]
@@ -21,7 +26,7 @@ on:
         description: Task-family split; holdout is only for final validation
       repetitions:
         type: number
-        default: 1
+        default: 3
         description: Attempts per case on each side; use 3 for a smoke sample
 
 jobs:
@@ -29,6 +34,7 @@ jobs:
     runs_on: linux-medium
     environment: production
     env:
+      FOCUSED_EXPERIMENT: ${{ inputs.experiment }}
       FOCUSED_CASE: ${{ inputs.case_id }}
       FOCUSED_SPLIT: ${{ inputs.split }}
       FOCUSED_REPETITIONS: ${{ inputs.repetitions }}

--- a/.eas/workflows/skill-eval-focused.yml
+++ b/.eas/workflows/skill-eval-focused.yml
@@ -1,0 +1,47 @@
+# Focused skill routing and source checks. All model calls run on EAS.
+name: skill-eval-focused
+
+defaults:
+  image: sdk-57
+  tools:
+    bun: '1.3.14'
+    node: '22.20.0'
+
+on:
+  workflow_dispatch:
+    inputs:
+      case_id:
+        type: string
+        default: native-form-advice
+        description: Case ID, or all to run the selected split
+      split:
+        type: choice
+        options: [development, validation, holdout]
+        default: development
+        description: Task-family split; holdout is only for final validation
+      repetitions:
+        type: number
+        default: 1
+        description: Attempts per case on each side; use 3 for a smoke sample
+
+jobs:
+  focused:
+    runs_on: linux-medium
+    environment: production
+    env:
+      FOCUSED_CASE: ${{ inputs.case_id }}
+      FOCUSED_SPLIT: ${{ inputs.split }}
+      FOCUSED_REPETITIONS: ${{ inputs.repetitions }}
+      SKILL_EVAL_REMOTE: '1'
+      CI: '1'
+    steps:
+      - uses: eas/checkout
+      - name: Compare focused cases against main
+        run: bash scripts/run-focused-evals.sh
+      - name: Upload reports, manifests, traces and app artifacts
+        if: ${{ always() }}
+        uses: eas/upload_artifact
+        with:
+          type: other
+          name: focused-skill-eval
+          path: focused-skill-eval

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
+      - name: Check evaluation CI helpers
+        run: |
+          python3 -m unittest discover -s scripts -p 'test_ci.py'
+          bash -n scripts/ci.sh
+          bash -n scripts/run-focused-evals.sh
+
       - name: Ensure that plugin version bump script is healthy
         id: version-check-test
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -182,7 +182,12 @@ MIT
 ## Evaluating skill changes
 
 The existing EAS `skill-eval-ci` workflow compares three complete app-building tasks
-against main. For focused routing and source-edit cases, use:
+against main. Adding the `eval` label to a PR also runs a focused routing smoke
+case inside both Notes jobs. Each Notes artifact includes a `focused/` report with
+raw traces and frozen catalog evidence. No local EAS login is needed to trigger
+this path; it uses the existing GitHub-to-EAS connection.
+
+For focused routing and source-edit cases with configurable splits/repetitions, use:
 
 ```sh
 eas workflow:run .eas/workflows/skill-eval-focused.yml

--- a/README.md
+++ b/README.md
@@ -201,9 +201,8 @@ the HTTP cases have executable behavior checks. These are controlled file-edit t
 For a larger development sample, add `-F case_id=all -F repetitions=3`. Validation and
 holdout task families require explicit `-F split=validation` or `-F split=holdout`.
 
-EAS reads workflow definitions from the default branch. The new standalone inputs and
-focused PR-comment section become available after merge; the existing label workflow
-already checks out the PR scripts and runs the pilot, whose results are in its artifact.
+The label workflow uses the PR workflow definition and scripts. Its comment summarizes
+the focused pilot; detailed results remain in the Notes PR artifact.
 
 Agent evaluations run in CI only. Validate cases locally without model calls:
 

--- a/README.md
+++ b/README.md
@@ -178,3 +178,31 @@ Submission details and telemetry controls live in `expo-skill-feedback`.
 ## License
 
 MIT
+
+## Evaluating skill changes
+
+The existing EAS `skill-eval-ci` workflow compares three complete app-building tasks
+against main. For focused routing and source-edit cases, use:
+
+```sh
+eas workflow:run .eas/workflows/skill-eval-focused.yml
+```
+
+This runs a small smoke comparison on EAS using the project's `production` credentials.
+Download `focused-skill-eval` and open `comparison.html`, then each side's `report.html`
+for expectations, raw trace evidence, source checks and pending behavior reviews.
+For a larger development sample, add `-F case_id=all -F repetitions=3`. Validation and
+holdout task families require explicit `-F split=validation` or `-F split=holdout`.
+
+Agent evaluations run in CI only. Validate cases locally without model calls:
+
+```sh
+git submodule update --init eval-harness
+(cd eval-harness && bun install --frozen-lockfile)
+bun eval-harness/eval_harness/evaluator/skill_invocation/focused/main.ts validate --plugin plugins/expo
+```
+
+Cases, fixtures and evaluator implementation live in the pinned `eval-harness` submodule.
+See its [focused evaluation guide](eval-harness/eval_harness/evaluator/skill_invocation/focused/README.md).
+Harness changes must be committed and pushed there before updating this repo's submodule
+pointer, so remote CI can fetch the exact implementation being reviewed.

--- a/README.md
+++ b/README.md
@@ -182,9 +182,9 @@ MIT
 ## Evaluating skill changes
 
 The existing EAS `skill-eval-ci` workflow compares three complete app-building tasks
-against main. Adding the `eval` label to a PR also runs a focused routing smoke
-case inside both Notes jobs. Each Notes artifact includes a `focused/` report with
-raw traces and frozen catalog evidence. No local EAS login is needed to trigger
+against main. Adding the `eval` label also runs a four-case focused pilot in the Notes PR
+job: three attempts per case with and without Expo skills (24 attempts). Its Notes PR
+artifact includes `focused/report.html`, outcome summaries, raw traces and frozen catalog evidence. No local EAS login is needed to trigger
 this path; it uses the existing GitHub-to-EAS connection.
 
 For focused routing and source-edit cases with configurable splits/repetitions, use:
@@ -193,11 +193,17 @@ For focused routing and source-edit cases with configurable splits/repetitions, 
 eas workflow:run .eas/workflows/skill-eval-focused.yml
 ```
 
-This runs a small smoke comparison on EAS using the project's `production` credentials.
-Download `focused-skill-eval` and open `comparison.html`, then each side's `report.html`
-for expectations, raw trace evidence, source checks and pending behavior reviews.
+This defaults to the same catalog-value pilot on EAS using the project's `production` credentials.
+Download `focused-skill-eval` and open `report.html` for outcomes, routing, costs and evidence.
+Use `-F experiment=catalog-change` to compare main against the candidate instead; that mode
+also writes `comparison.html` and per-side reports. Advice reviews remain pending, while
+the HTTP cases have executable behavior checks. These are controlled file-edit tasks, not native app validation.
 For a larger development sample, add `-F case_id=all -F repetitions=3`. Validation and
 holdout task families require explicit `-F split=validation` or `-F split=holdout`.
+
+EAS reads workflow definitions from the default branch. The new standalone inputs and
+focused PR-comment section become available after merge; the existing label workflow
+already checks out the PR scripts and runs the pilot, whose results are in its artifact.
 
 Agent evaluations run in CI only. Validate cases locally without model calls:
 

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -30,7 +30,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-FINGERPRINT_SCHEMA_VERSION = 1
+FINGERPRINT_SCHEMA_VERSION = 2
 SUPPORTED_MANIFEST_SCHEMA_VERSIONS = {1}
 
 
@@ -123,6 +123,9 @@ def cmd_fingerprint(args: argparse.Namespace) -> None:
         "harness_sha256": harness_revision(args.harness_dir),
         "eval_config_sha256": eval_config_hash(args.prd, args.prd_skills, args.prd_id, args.scenario),
         "agent": args.agent,
+        "agent_cli_version": args.agent_version,
+        "prompt_variant": args.prompt_variant,
+        "runner_image": args.runner_image,
         "model": args.model,
         "scenario": args.scenario,
         "prd_id": args.prd_id,
@@ -327,6 +330,9 @@ def build_parser() -> argparse.ArgumentParser:
     fp.add_argument("--prd-id", required=True)
     fp.add_argument("--scenario", required=True)
     fp.add_argument("--agent", required=True)
+    fp.add_argument("--agent-version", default="unspecified")
+    fp.add_argument("--prompt-variant", default="baseline")
+    fp.add_argument("--runner-image", default="unspecified")
     fp.add_argument("--model", default="unspecified")
     fp.add_argument("--repetitions", default="1")
     fp.set_defaults(func=cmd_fingerprint)

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -307,10 +307,30 @@ def cmd_print_outputs(args: argparse.Namespace) -> None:
         "syntax_ok": syntax_ok,
         "bundle_ok": bundle_ok,
         "failing": failing,
+        "focused": focused_summary(Path(args.metrics_path).parent / "focused" / "summary.json"),
     }
 
     for key, value in fields.items():
         print(f"{key}={shell_quote(value)}")
+
+
+def focused_summary(path: Path) -> str:
+    """Only evaluated outcomes enter the denominator; pending is never a pass."""
+    if not path.exists():
+        return "Focused pilot not available; see job artifacts."
+    try:
+        rows = json.loads(path.read_text(encoding="utf-8"))
+        if not rows:
+            return "No focused attempts recorded."
+        return "<br>".join(
+            f"{row['id']} ({row['skill_mode']}): "
+            f"{row['outcome_passed']}/{row['outcome_passed'] + row['outcome_failed']} outcomes passed; "
+            f"{row['outcome_pending']} pending; {row['outcome_unavailable']} unavailable; "
+            f"{row['attempted']} attempted"
+            for row in rows
+        )
+    except (ValueError, KeyError, TypeError):
+        return "Invalid focused summary; inspect job artifacts."
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -169,11 +169,7 @@ author_and_evaluate() {
     export SKILL_PLUGIN_DIR="$plugin_dir"
     bash ./eval-harness/eval_harness/app_builder/scripts/author-app.sh
 
-    AUTHORED_ARTIFACT="$(pwd)/eval-harness" \
-    SCENARIO="$scenario" \
-    OUT_DIR="$out_dir" \
-    PRD_SKILLS="$(pwd)/eval-harness/dataset/prd_skills.json" \
-    bash ./eval-harness/eval_harness/evaluator/skill_invocation/scripts/eval-skill-use.sh
+    analyze_authored_app "$scenario" "$out_dir"
   fi
 
   # Warn only: this function swallows failures on purpose (see above), and
@@ -193,6 +189,23 @@ author_and_evaluate() {
 
   tar -czf "$tarball" "$out_dir" 2>/dev/null || true
   return "$focused_status"
+}
+
+# The harness now emits a canonical authored-app tree and restricts its shell
+# analyzer to its canonical report directory. Copy that report into the per-job
+# artifact location expected by the skills repository's existing workflows.
+analyze_authored_app() {
+  (
+    set -euo pipefail
+    local scenario="$1" out_dir="$2"
+    AUTHORED_ARTIFACT="$(pwd)/eval-harness/authored-app" \
+    SCENARIO="$scenario" \
+    OUT_DIR=skill-eval-report \
+    PRD_SKILLS="$(pwd)/eval-harness/dataset/prd_skills.json" \
+    bash ./eval-harness/eval_harness/evaluator/skill_invocation/scripts/eval-skill-use.sh
+    mkdir -p "$out_dir"
+    cp -R eval-harness/skill-eval-report/. "$out_dir/"
+  )
 }
 
 # Small CI-only routing probe, shared by the label workflow and manual runner.
@@ -234,11 +247,7 @@ author_and_evaluate_baseline() {
     export SKILL_PLUGIN_DIR="$plugin_dir"
     bash ./eval-harness/eval_harness/app_builder/scripts/author-app.sh
 
-    AUTHORED_ARTIFACT="$(pwd)/eval-harness" \
-    SCENARIO="$scenario" \
-    OUT_DIR="$out_dir" \
-    PRD_SKILLS="$(pwd)/eval-harness/dataset/prd_skills.json" \
-    bash ./eval-harness/eval_harness/evaluator/skill_invocation/scripts/eval-skill-use.sh
+    analyze_authored_app "$scenario" "$out_dir"
 
     [ -f "$out_dir/metrics.json" ] || {
       echo "❌ skill-eval wrote no $out_dir/metrics.json -- refusing to cache this baseline" >&2

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -178,8 +178,8 @@ author_and_evaluate() {
     echo "❌ skill-eval wrote no $out_dir/metrics.json -- this job's PR comment cells will all read '?'" >&2
   fi
 
-  # The existing label-triggered workflow reads its YAML from main, but checks
-  # out this PR's scripts. The candidate Notes job runs a paired catalog-value
+  # The label-triggered workflow checks out this PR. The candidate Notes job
+  # runs a paired catalog-value
   # pilot; the main job must not duplicate these 24 attempts.
   # Keep the report inside the artifact this job already uploads.
   local focused_status=0

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -182,7 +182,34 @@ author_and_evaluate() {
     echo "❌ skill-eval wrote no $out_dir/metrics.json -- this job's PR comment cells will all read '?'" >&2
   fi
 
+  # The existing label-triggered workflow reads its YAML from main, but checks
+  # out this PR's scripts. Run one focused case on each Notes side here so the
+  # new runner is exercised before its standalone workflow has been merged.
+  # Keep the report inside the artifact this job already uploads.
+  local focused_status=0
+  if [ "${PRD:-}" = "dataset/prds/notes/prd/mvp.txt" ]; then
+    focused_smoke "$plugin_dir" "$out_dir/focused" || focused_status=$?
+  fi
+
   tar -czf "$tarball" "$out_dir" 2>/dev/null || true
+  return "$focused_status"
+}
+
+# Small CI-only routing probe, shared by the label workflow and manual runner.
+# Ordinary behavioral misses remain advisory; infrastructure errors fail the job.
+focused_smoke() {
+  (
+    set -euo pipefail
+    local plugin_dir="$1" out_dir="$2"
+    [ -n "${CI:-}" ] || { echo "Focused agent runs require CI" >&2; exit 1; }
+    install_harness_deps
+    if ! command -v claude >/dev/null 2>&1 || [ "$(claude --version | cut -d ' ' -f 1)" != "$AGENT_CLI_VERSION" ]; then
+      npm install -g "@anthropic-ai/claude-code@$AGENT_CLI_VERSION"
+    fi
+    SKILL_EVAL_REMOTE=1 bun eval-harness/eval_harness/evaluator/skill_invocation/focused/main.ts run \
+      --plugin "$plugin_dir" --out "$out_dir" --model "$AGENT_MODEL" \
+      --case native-form-advice --split development --repetitions 1
+  )
 }
 
 # Runs author-app.sh then eval-skill-use.sh directly into OUT_DIR -- no

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -179,11 +179,11 @@ author_and_evaluate() {
   fi
 
   # The existing label-triggered workflow reads its YAML from main, but checks
-  # out this PR's scripts. Run one focused case on each Notes side here so the
-  # new runner is exercised before its standalone workflow has been merged.
+  # out this PR's scripts. The candidate Notes job runs a paired catalog-value
+  # pilot; the main job must not duplicate these 24 attempts.
   # Keep the report inside the artifact this job already uploads.
   local focused_status=0
-  if [ "${PRD:-}" = "dataset/prds/notes/prd/mvp.txt" ]; then
+  if [ "${PRD:-}" = "dataset/prds/notes/prd/mvp.txt" ] && [ "$plugin_dir" = "$(pwd)/plugins/expo" ]; then
     focused_smoke "$plugin_dir" "$out_dir/focused" || focused_status=$?
   fi
 
@@ -221,7 +221,7 @@ focused_smoke() {
     fi
     SKILL_EVAL_REMOTE=1 bun eval-harness/eval_harness/evaluator/skill_invocation/focused/main.ts run \
       --plugin "$plugin_dir" --out "$out_dir" --model "$AGENT_MODEL" \
-      --case native-form-advice --split development --repetitions 1
+      --case pilot --split development --repetitions 3 --skill-mode both
   )
 }
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -13,6 +13,7 @@
 # from its menu, so nothing triggers and every trigger score reads 0. Nobody
 # documents this, we hit it in CI. Shared here so both workflows stay in sync.
 export AGENT_MODEL="${AGENT_MODEL:-sonnet[1m]}"
+export AGENT_CLI_VERSION="${AGENT_CLI_VERSION:-2.1.267}"
 
 # Configures the (private, token-scoped) eval-harness submodule fetch and
 # initializes it. Called by every function below that needs eval-harness.
@@ -83,7 +84,10 @@ fingerprint_main_content() {
       --prd-id "${PRD_ID}" \
       --scenario "${SCENARIO}" \
       --agent "${AGENT}" \
-      --model "${AGENT_MODEL}"
+      --model "${AGENT_MODEL}" \
+      --agent-version "${AGENT_CLI_VERSION}" \
+      --prompt-variant "${PROMPT_VARIANT:-baseline}" \
+      --runner-image sdk-57
   )
 }
 

--- a/scripts/run-focused-evals.sh
+++ b/scripts/run-focused-evals.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# EAS entrypoint. No model execution belongs in local development checks.
+set -euo pipefail
+
+[ "${SKILL_EVAL_REMOTE:-}" = 1 ] && [ -n "${CI:-}" ] || {
+  echo "Submit .eas/workflows/skill-eval-focused.yml to run agents on EAS."
+  exit 1
+}
+
+# Fetch our public baseline before the private-submodule credential rewrite.
+git fetch origin main
+baseline_root="$(mktemp -d)"
+trap 'rm -rf "$baseline_root"' EXIT
+git archive origin/main plugins/expo | tar -x -C "$baseline_root"
+bash scripts/ci.sh fetch_eval_harness
+bash scripts/ci.sh install_harness_deps
+# Pin the runtime for both sides. The focused manifest also records --version.
+export AGENT_CLI_VERSION="${AGENT_CLI_VERSION:-2.1.267}"
+npm install -g "@anthropic-ai/claude-code@$AGENT_CLI_VERSION"
+
+focused_cli=eval-harness/eval_harness/evaluator/skill_invocation/focused/main.ts
+out="$(pwd)/focused-skill-eval"
+mkdir -p "$out"
+case_args=()
+if [ "${FOCUSED_CASE:-native-form-advice}" != all ]; then
+  case_args=(--case "${FOCUSED_CASE:-native-form-advice}")
+fi
+
+run_side() {
+  local plugin="$1" destination="$2"
+  # The explicit branch supports macOS Bash 3.2 as well as EAS Linux.
+  if [ "${#case_args[@]}" -gt 0 ]; then
+    bun "$focused_cli" run --plugin "$plugin" --out "$destination" \
+      --model 'sonnet[1m]' --split "${FOCUSED_SPLIT:-development}" \
+      --repetitions "${FOCUSED_REPETITIONS:-1}" "${case_args[@]}"
+  else
+    bun "$focused_cli" run --plugin "$plugin" --out "$destination" \
+      --model 'sonnet[1m]' --split "${FOCUSED_SPLIT:-development}" \
+      --repetitions "${FOCUSED_REPETITIONS:-1}"
+  fi
+}
+
+main_status=0
+candidate_status=0
+run_side "$baseline_root/plugins/expo" "$out/main" || main_status=$?
+run_side "$(pwd)/plugins/expo" "$out/candidate" || candidate_status=$?
+if [ -f "$out/main/metrics.json" ] && [ -f "$out/candidate/metrics.json" ]; then
+  bun "$focused_cli" compare --baseline "$out/main/metrics.json" \
+    --candidate "$out/candidate/metrics.json" --out "$out"
+fi
+[ "$main_status" = 0 ] && [ "$candidate_status" = 0 ]

--- a/scripts/run-focused-evals.sh
+++ b/scripts/run-focused-evals.sh
@@ -22,23 +22,30 @@ focused_cli=eval-harness/eval_harness/evaluator/skill_invocation/focused/main.ts
 out="$(pwd)/focused-skill-eval"
 mkdir -p "$out"
 case_args=()
-if [ "${FOCUSED_CASE:-native-form-advice}" != all ]; then
-  case_args=(--case "${FOCUSED_CASE:-native-form-advice}")
+if [ "${FOCUSED_CASE:-pilot}" != all ]; then
+  case_args=(--case "${FOCUSED_CASE:-pilot}")
 fi
 
 run_side() {
-  local plugin="$1" destination="$2"
+  local plugin="$1" destination="$2" skill_mode="${3:-with-expo}"
   # The explicit branch supports macOS Bash 3.2 as well as EAS Linux.
   if [ "${#case_args[@]}" -gt 0 ]; then
     bun "$focused_cli" run --plugin "$plugin" --out "$destination" \
-      --model 'sonnet[1m]' --split "${FOCUSED_SPLIT:-development}" \
-      --repetitions "${FOCUSED_REPETITIONS:-1}" "${case_args[@]}"
+      --model 'sonnet[1m]' --skill-mode "$skill_mode" --split "${FOCUSED_SPLIT:-development}" \
+      --repetitions "${FOCUSED_REPETITIONS:-3}" "${case_args[@]}"
   else
     bun "$focused_cli" run --plugin "$plugin" --out "$destination" \
-      --model 'sonnet[1m]' --split "${FOCUSED_SPLIT:-development}" \
-      --repetitions "${FOCUSED_REPETITIONS:-1}"
+      --model 'sonnet[1m]' --skill-mode "$skill_mode" --split "${FOCUSED_SPLIT:-development}" \
+      --repetitions "${FOCUSED_REPETITIONS:-3}"
   fi
 }
+
+if [ "${FOCUSED_EXPERIMENT:-catalog-value}" = catalog-value ]; then
+  # One catalog, alternating presence/absence conditions inside each repetition.
+  run_side "$(pwd)/plugins/expo" "$out" both
+  exit $?
+fi
+[ "$FOCUSED_EXPERIMENT" = catalog-change ] || { echo "Unknown experiment" >&2; exit 2; }
 
 main_status=0
 candidate_status=0

--- a/scripts/test_ci.py
+++ b/scripts/test_ci.py
@@ -45,6 +45,14 @@ class FingerprintTests(unittest.TestCase):
 
 
 class LabelWorkflowTests(unittest.TestCase):
+    def test_pending_reviews_are_not_counted_as_success(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "summary.json"
+            self.assertIn("not available", ci.focused_summary(path))
+            path.write_text(json.dumps([{"id": "advice", "skill_mode": "with-expo", "outcome_passed": 0,
+                "outcome_failed": 0, "outcome_pending": 3, "outcome_unavailable": 0, "attempted": 3}]))
+            self.assertIn("0/0 outcomes passed; 3 pending", ci.focused_summary(path))
+
     def test_canonical_harness_report_is_copied_into_job_artifact(self):
         ci_script = str(Path(__file__).with_name("ci.sh").resolve())
         with tempfile.TemporaryDirectory() as directory:
@@ -76,7 +84,7 @@ focused_smoke() { mkdir -p "$2"; echo smoke > "$2/report.html"; return "$focused
 focused_rc="$3"
 export PRD=dataset/prds/notes/prd/mvp.txt
 cd "$2"
-author_and_evaluate true cached plugin report skills_available_unmentioned report.tar.gz
+author_and_evaluate true cached "$PWD/plugins/expo" report skills_available_unmentioned report.tar.gz
 """
         for code in [0, 1]:
             with self.subTest(focused_exit=code), tempfile.TemporaryDirectory() as directory:
@@ -87,6 +95,21 @@ author_and_evaluate true cached plugin report skills_available_unmentioned repor
                 self.assertEqual(result.returncode, code, result.stderr)
                 self.assertTrue((root / "report/focused/report.html").exists())
                 self.assertTrue((root / "report.tar.gz").exists())
+
+    def test_main_notes_job_does_not_duplicate_the_pilot(self):
+        ci_script = str(Path(__file__).with_name("ci.sh").resolve())
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "cached").mkdir()
+            (root / "cached/metrics.json").write_text("{}")
+            result = subprocess.run(["bash", "-c", r'''
+source "$1" true
+focused_smoke() { echo "unexpected pilot" >&2; return 99; }
+export PRD=dataset/prds/notes/prd/mvp.txt
+author_and_evaluate true cached /tmp/plugins-main/plugins/expo report skills_available_unmentioned report.tar.gz
+''', "test", ci_script], cwd=root, capture_output=True, text=True)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertNotIn("unexpected pilot", result.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/test_ci.py
+++ b/scripts/test_ci.py
@@ -5,6 +5,7 @@ import io
 import json
 from pathlib import Path
 import tempfile
+import subprocess
 import unittest
 from unittest.mock import patch
 
@@ -41,6 +42,28 @@ class FingerprintTests(unittest.TestCase):
                           ["--repetitions", "3"]]:
                 with self.subTest(extra=extra):
                     self.assertNotEqual(baseline, fingerprint(extra))
+
+
+class LabelWorkflowTests(unittest.TestCase):
+    def test_cached_notes_jobs_run_focused_probe_and_upload_diagnostics(self):
+        ci_script = str(Path(__file__).with_name("ci.sh").resolve())
+        shell = r"""
+source "$1" true
+focused_smoke() { mkdir -p "$2"; echo smoke > "$2/report.html"; return "$focused_rc"; }
+focused_rc="$3"
+export PRD=dataset/prds/notes/prd/mvp.txt
+cd "$2"
+author_and_evaluate true cached plugin report skills_available_unmentioned report.tar.gz
+"""
+        for code in [0, 1]:
+            with self.subTest(focused_exit=code), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                (root / "cached").mkdir()
+                (root / "cached/metrics.json").write_text("{}")
+                result = subprocess.run(["bash", "-c", shell, "test", ci_script, directory, str(code)], capture_output=True, text=True)
+                self.assertEqual(result.returncode, code, result.stderr)
+                self.assertTrue((root / "report/focused/report.html").exists())
+                self.assertTrue((root / "report.tar.gz").exists())
 
 
 if __name__ == "__main__":

--- a/scripts/test_ci.py
+++ b/scripts/test_ci.py
@@ -45,6 +45,29 @@ class FingerprintTests(unittest.TestCase):
 
 
 class LabelWorkflowTests(unittest.TestCase):
+    def test_canonical_harness_report_is_copied_into_job_artifact(self):
+        ci_script = str(Path(__file__).with_name("ci.sh").resolve())
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            analyzer = root / "eval-harness/eval_harness/evaluator/skill_invocation/scripts/eval-skill-use.sh"
+            analyzer.parent.mkdir(parents=True)
+            analyzer.write_text('''set -eu
+test "$AUTHORED_ARTIFACT" = "$PWD/eval-harness/authored-app"
+test "$SCENARIO" = skills_available_unmentioned
+test "$OUT_DIR" = skill-eval-report
+test "$PRD_SKILLS" = "$PWD/eval-harness/dataset/prd_skills.json"
+mkdir -p eval-harness/skill-eval-report
+echo '{"runs":[]}' > eval-harness/skill-eval-report/metrics.json
+echo report > eval-harness/skill-eval-report/report.html
+''')
+            result = subprocess.run(
+                ["bash", ci_script, "analyze_authored_app", "skills_available_unmentioned", "notes-report"],
+                cwd=root, capture_output=True, text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(json.loads((root / "notes-report/metrics.json").read_text()), {"runs": []})
+            self.assertEqual((root / "notes-report/report.html").read_text(), "report\n")
+
     def test_cached_notes_jobs_run_focused_probe_and_upload_diagnostics(self):
         ci_script = str(Path(__file__).with_name("ci.sh").resolve())
         shell = r"""

--- a/scripts/test_ci.py
+++ b/scripts/test_ci.py
@@ -1,0 +1,47 @@
+"""Offline tests for evaluation cache identity; never launches an agent."""
+import contextlib
+import importlib.util
+import io
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+spec = importlib.util.spec_from_file_location("ci", Path(__file__).with_name("ci.py"))
+ci = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ci)
+
+
+class FingerprintTests(unittest.TestCase):
+    def test_runtime_prompt_and_runner_changes_invalidate_cache(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            plugin = root / "plugin"
+            plugin.mkdir()
+            (plugin / "SKILL.md").write_text("skill body")
+            prd = root / "prd.txt"
+            prd.write_text("Build a notes app")
+            labels = root / "skills.json"
+            labels.write_text(json.dumps({"notes": {"required": ["expo-overview"], "unlisted": "observe"}}))
+            argv = ["fingerprint", "--skill-dir", str(plugin), "--harness-dir", str(root),
+                    "--prd", str(prd), "--prd-skills", str(labels), "--prd-id", "notes",
+                    "--scenario", "skills_available_unmentioned", "--agent", "claude-code"]
+
+            def fingerprint(extra):
+                output = io.StringIO()
+                with patch.object(ci, "harness_revision", return_value="a" * 40), contextlib.redirect_stdout(output):
+                    ci.cmd_fingerprint(ci.build_parser().parse_args(argv + extra))
+                return json.loads(output.getvalue())["fingerprint"]
+
+            baseline = fingerprint([])
+            self.assertEqual(baseline, fingerprint([]))
+            for extra in [["--agent-version", "2.1.267"], ["--prompt-variant", "minimal"],
+                          ["--runner-image", "sdk-57"], ["--model", "another-model"],
+                          ["--repetitions", "3"]]:
+                with self.subTest(extra=extra):
+                    self.assertNotEqual(baseline, fingerprint(extra))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_ci.py
+++ b/scripts/test_ci.py
@@ -45,6 +45,12 @@ class FingerprintTests(unittest.TestCase):
 
 
 class LabelWorkflowTests(unittest.TestCase):
+    def test_eas_workflows_fit_the_server_file_limit(self):
+        root = Path(__file__).resolve().parents[1]
+        for path in (root / ".eas/workflows").glob("*.y*ml"):
+            with self.subTest(workflow=path.name):
+                self.assertLessEqual(len(path.read_bytes()), 16384)
+
     def test_pending_reviews_are_not_counted_as_success(self):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "summary.json"


### PR DESCRIPTION
Measure whether Expo skills improve task outcomes, separately from whether they were requested or delivered. Add a CI-only focused runner alongside the existing three app-generation comparisons, with matched with/without-Expo conditions and three trials per case.

The `eval-focused` PR label runs only the four-case outcome experiment: Expo config repair, preserving already-correct config, HTTP repair, and signing diagnosis. It posts an independent summary with graded coverage, observed differences, failed criteria and next investigations. The existing `eval` label includes the same experiment in its Notes candidate job. A manual workflow also supports main-versus-candidate comparisons.

The companion harness verifies config behavior using Expo's pinned config loader and HTTP behavior with executable tests. Signing advice receives provisional, evidence-quoted model judgments only after a small synthetic calibration gate; other advice remains pending. Artifacts retain raw traces, manifests, frozen skills, authored output, outcome evidence, separate author/judge costs and `findings.json`. Native UI/runtime correctness is not claimed.

Validation: harness typecheck, 230 TypeScript and 192 Python tests on Node 24; new verifier/judge adapter tests also pass with the workflow's Node 22.20.0. Eight offline CI-helper tests, shell syntax and current EAS JSON-schema validation pass. Direct EAS server validation is blocked by this session being signed out; remote submission uses the existing GitHub-to-EAS connection. No local model evaluations.

Companion harness PR: https://github.com/expo/eval-experiments/pull/49


The first signal run exposed a grader evidence bug: quotes that omitted Markdown bold markers were rejected. Normalize only paired bold markers and whitespace, keep altered wording invalid, log judge errors, and support offline replay of saved responses with calibration/condition checks and provenance. Replaying the actual artifact recovers 24/24 passing outcomes (signing remains provisional model grading), with no author or judge reruns. The original EAS run remains errored. The PR comment now uses a condition-comparison table and expandable costs, median times, skill delivery and grader-error details.
