### PR TITLE
[expo-ui] Document RNHostView matchContents sizing

### DIFF
--- a/plugins/expo/.claude-plugin/plugin.json
+++ b/plugins/expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo apps",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.codex-plugin/plugin.json
+++ b/plugins/expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Official Expo skills for building, deploying, upgrading, and debugging Expo and React Native apps.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.cursor-plugin/plugin.json
+++ b/plugins/expo/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Expo",
   "displayName": "Expo",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/.grok-plugin/plugin.json
+++ b/plugins/expo/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web.",
   "author": {
     "name": "Expo Team",

--- a/plugins/expo/skills/expo-ui/references/jetpack-compose.md
+++ b/plugins/expo/skills/expo-ui/references/jetpack-compose.md
@@ -60,6 +60,36 @@ import { fillMaxWidth, paddingAll } from "@expo/ui/jetpack-compose/modifiers";
 - `RNHostView` embeds React Native components inside a Jetpack Compose tree (the same concept as in `@expo/ui/swift-ui`) — wrap any RN child in `<RNHostView>`.
 - If a required composable or modifier is missing in Expo UI, it can be extended via a local Expo module. See: https://docs.expo.dev/guides/expo-ui-jetpack-compose/extending/index.md. Confirm with the user before extending.
 
+## `RNHostView` sizing with `matchContents`
+
+With `matchContents`, `RNHostView` is a leaf in the Yoga tree — it measures its hosted child itself, and the width its native parent offers never reaches that child. The measure constraints come only from point-valued `minWidth` / `maxWidth` / `minHeight` / `maxHeight` on the hosted child; percentages are ignored and anything unset is unbounded.
+
+So unbounded `<Text>` measures at its full single-line width and does **not** wrap — it runs past the screen edge. Bound the hosted child yourself:
+
+```jsx
+// ✅ wraps at 280
+<RNHostView matchContents>
+  <View style={{ maxWidth: 280 }}>
+    <Text>A long string that has to wrap when the width is limited</Text>
+  </View>
+</RNHostView>
+
+// ❌ measures on one line and overflows
+<RNHostView matchContents>
+  <Text>A long string that has to wrap when the width is limited</Text>
+</RNHostView>
+```
+
+- `maxWidth` is the bound the constraints read — use it when the view should still hug shorter content. A fixed `width` also works, since Yoga resolves it while measuring.
+- Add `minHeight` when the wrapped content must not collapse below a floor.
+- Without `matchContents` the host fills its native parent, so text wraps on its own and needs no bound.
+
+Other `RNHostView` layout rules:
+
+- Only the **first** child is measured and laid out. Wrap several views in one parent `View` and let that view arrange them.
+- With `matchContents`, `alignSelf: 'auto' | 'stretch'` is forced to `flex-start` so the node can hug its content.
+- `onLayout` on `RNHostView` reports the size it settled on — use it to see what `matchContents` actually measured.
+
 ## Key Components
 
 - **LazyColumn** — Use instead of react-native `ScrollView`/`FlatList` for scrollable lists. Wrap in `<Host style={{ flex: 1 }}>`. Not suitable for large lists — each item is a JSX node processed on the JS thread, which causes noticeable slowdowns at scale.

--- a/plugins/expo/skills/expo-ui/references/swift-ui.md
+++ b/plugins/expo/skills/expo-ui/references/swift-ui.md
@@ -65,6 +65,36 @@ import { Pressable } from "react-native";
 
 - If a required modifier or View is missing in Expo UI, it can be extended via a local Expo module. See: https://docs.expo.dev/guides/expo-ui-swift-ui/extending/index.md. Confirm with the user before extending.
 
+## `RNHostView` sizing with `matchContents`
+
+With `matchContents`, `RNHostView` is a leaf in the Yoga tree — it measures its hosted child itself, and the width its native parent offers never reaches that child. The measure constraints come only from point-valued `minWidth` / `maxWidth` / `minHeight` / `maxHeight` on the hosted child; percentages are ignored and anything unset is unbounded.
+
+So unbounded `<Text>` measures at its full single-line width and does **not** wrap — it runs past the screen edge. Bound the hosted child yourself:
+
+```jsx
+// ✅ wraps at 280
+<RNHostView matchContents>
+  <View style={{ maxWidth: 280 }}>
+    <Text>A long string that has to wrap when the width is limited</Text>
+  </View>
+</RNHostView>
+
+// ❌ measures on one line and overflows
+<RNHostView matchContents>
+  <Text>A long string that has to wrap when the width is limited</Text>
+</RNHostView>
+```
+
+- `maxWidth` is the bound the constraints read — use it when the view should still hug shorter content. A fixed `width` also works, since Yoga resolves it while measuring.
+- Add `minHeight` when the wrapped content must not collapse below a floor.
+- Without `matchContents` the host fills its native parent, so text wraps on its own and needs no bound.
+
+Other `RNHostView` layout rules:
+
+- Only the **first** child is measured and laid out. Wrap several views in one parent `View` and let that view arrange them.
+- With `matchContents`, `alignSelf: 'auto' | 'stretch'` is forced to `flex-start` so the node can hug its content.
+- `onLayout` on `RNHostView` reports the size it settled on — use it to see what `matchContents` actually measured.
+
 ## useNativeState
 
 `useNativeState` creates observable state that updates synchronously on the UI thread via worklets, enabling immediate native state changes without waiting for a React render cycle. Requires `react-native-worklets` — without it updates still go through React and flickering remains. Best for real-time interactions where synchronous updates matter, e.g. a text field that masks or formats input as the user types.

--- a/plugins/expo/skills/expo-ui/references/universal.md
+++ b/plugins/expo/skills/expo-ui/references/universal.md
@@ -29,6 +29,9 @@ import { Host, Column, Button, Text } from '@expo/ui';
 | Controls | `Button`, `Switch`, `Checkbox`, `Slider`, `TextInput`, `Picker` |
 | Disclosure & presentation | `BottomSheet`, `Collapsible` |
 | Collections & forms | `List` (with `ListItem`), `FieldGroup` |
+| Interop | `RNHostView` (hosts React Native views inside an `@expo/ui` tree) |
+
+> **`RNHostView matchContents` does not wrap text.** With `matchContents` the host measures its child itself — the width the native parent offers never reaches that child, so unbounded `<Text>` measures on one line and overflows. Give the hosted child a `maxWidth` (or a fixed `width`). It also lays out only its first child, so wrap several views in one parent `View`. See `swift-ui.md` / `jetpack-compose.md` for the full rules.
 
 > **`List` is not suitable for large lists.** Each `ListItem` is a JSX node processed on the JS thread — for large datasets this causes noticeable slowdowns.
 


### PR DESCRIPTION
# Why

`RNHostView` with `matchContents` measures its hosted child itself, from that child's own point-valued `minWidth` / `maxWidth` / `minHeight` / `maxHeight`. The width the native parent offers never reaches the child. So an unbounded `<Text>` measures at its full single-line width and runs off the screen instead of wrapping.

Nothing in the `expo-ui` skill said this, so agents write the overflowing version.

Source: https://github.com/expo/expo/pull/49483

# How

- `references/swift-ui.md` and `references/jetpack-compose.md`: new `RNHostView` sizing section with a ✅ / ❌ pair, plus three rules the PR establishes — only the first child is measured and laid out, `alignSelf: 'auto' | 'stretch'` is forced to `flex-start`, and `onLayout` reports the size the host settled on.
- `references/universal.md`: an `RNHostView` row in the components table and a compact note pointing at the platform references.
- Bumped all four plugin manifests to 1.13.2.

The guidance is scoped to `matchContents`. Without it the host fills its native parent and text wraps on its own, which the new section says explicitly.

# Test Plan

```
bun scripts/check-skill-limits.ts             # passes
bun scripts/check-plugin-version-bump.ts origin/main   # passes, 1.13.1 → 1.13.2
bun scripts/check-overview-routing.ts         # passes
claude plugin validate .                      # passes
claude plugin validate ./plugins/expo         # passes
```

Behaviour claims are taken from the merged expo/expo PR — `ExpoViewShadowNode::hostedContentConstraints` for which style bounds the measure reads, `ExpoViewComponentDescriptor::adopt` for the `alignSelf` override, and the `ExpoUIRNHostViewSize` test suite (`honours the hosted view's own maxWidth and minHeight`) for the wrapping case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Np8hnE1biHAoRiAcx42vqZ